### PR TITLE
feat: implement messaging feature with conversation and message schemas, routing, and tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
+    "@tanstack/react-router": "^1.170.17",
     "@wordpress/theme": "^0.17.0",
     "@wordpress/ui": "^0.17.0",
     "react": "^18.3.1",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.13.2",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.2(react@18.3.1)
+      '@tanstack/react-router':
+        specifier: ^1.170.17
+        version: 1.170.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/theme':
         specifier: ^0.17.0
         version: 0.17.0(@types/react@18.3.31)(postcss@8.5.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))
@@ -33,6 +36,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -752,6 +758,10 @@ packages:
   '@tannin/sprintf@1.3.3':
     resolution: {integrity: sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==}
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
 
@@ -759,6 +769,26 @@ packages:
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-router@1.170.17':
+    resolution: {integrity: sha512-ppLkjCfSMaeug9rmFRYzOd4TIqWV+yTE7tzIny7alJsSnM7w4lzEZm6eqCehG0SPetpZ0R3K+UnanSmBgOAVcQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.14':
+    resolution: {integrity: sha512-Mo3hwx0qB0cJsVYGDjG0+Ouf7VV74h/vsoDMGztdlyzDanp4gBA2s7IVvm6hFrmQM6GpD9F0Z7SqD7OldfLE7g==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -782,6 +812,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1087,6 +1123,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1242,6 +1281,10 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isbot@5.2.0:
+    resolution: {integrity: sha512-gbZiGCb4B5xaoxg9mS7koAyRdvJnArk10VLSHOgz6rtBG93/pi1xOFaVvXMKZ7JXgyZ8zAbNRK5uIBdIUTFSqw==}
+    engines: {node: '>=18'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1543,6 +1586,16 @@ packages:
 
   sentence-case@3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   set-cookie-parser@3.1.1:
     resolution: {integrity: sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==}
@@ -2313,12 +2366,39 @@ snapshots:
 
   '@tannin/sprintf@1.3.3': {}
 
+  '@tanstack/history@1.162.0': {}
+
   '@tanstack/query-core@5.101.2': {}
 
   '@tanstack/react-query@5.101.2(react@18.3.1)':
     dependencies:
       '@tanstack/query-core': 5.101.2
       react: 18.3.1
+
+  '@tanstack/react-router@1.170.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.171.14
+      isbot: 5.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/router-core@1.171.14':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -2349,6 +2429,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 
@@ -2703,6 +2787,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie@1.1.1: {}
 
   css-tree@3.2.1:
@@ -2851,6 +2937,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isbot@5.2.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3173,6 +3261,12 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
       upper-case-first: 2.0.2
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   set-cookie-parser@3.1.1: {}
 

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Link, Outlet } from '@tanstack/react-router'
+
+import { Card, Stack, Text } from './ui'
+
+export function Layout() {
+	return (
+		<Stack direction="column" gap="lg">
+			<Link to="/">
+				<Text variant="heading-lg" render={<h1 />}>
+					AlphOne
+				</Text>
+			</Link>
+			<Card.Root>
+				<Card.Content>
+					<Outlet />
+				</Card.Content>
+			</Card.Root>
+		</Stack>
+	)
+}

--- a/frontend/src/api/whatsapp.ts
+++ b/frontend/src/api/whatsapp.ts
@@ -13,10 +13,33 @@ const conversationSchema = z.object({
 
 export type Conversation = z.infer<typeof conversationSchema>
 
+const messageSchema = z.object({
+	id: z.string(),
+	external_id: z.string(),
+	direction: z.string(),
+	content: z.string(),
+	content_type: z.string(),
+	sent_at: z.coerce.date(),
+})
+
+export type Message = z.infer<typeof messageSchema>
+
 export async function fetchConversations(): Promise<Conversation[]> {
 	const response = await fetch('/api/plugins/whatsapp/conversations')
 	if (!response.ok) {
 		throw new Error(`listing conversations failed with status ${response.status}`)
 	}
 	return z.array(conversationSchema).parse(await response.json())
+}
+
+export async function fetchMessages(
+	conversationId: string,
+): Promise<Message[]> {
+	const response = await fetch(
+		`/api/plugins/whatsapp/conversations/${conversationId}/messages`,
+	)
+	if (!response.ok) {
+		throw new Error(`listing messages failed with status ${response.status}`)
+	}
+	return z.array(messageSchema).parse(await response.json())
 }

--- a/frontend/src/inbox/Inbox.test.tsx
+++ b/frontend/src/inbox/Inbox.test.tsx
@@ -1,26 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { HttpResponse, http } from 'msw'
 import { expect, test } from 'vitest'
 
+import { renderAt } from '../test/render'
 import { server } from '../test/setup'
-import { Inbox } from './Inbox'
-
-function renderInbox() {
-	const client = new QueryClient({
-		defaultOptions: { queries: { retry: false } },
-	})
-	render(
-		<QueryClientProvider client={client}>
-			<Inbox />
-		</QueryClientProvider>,
-	)
-}
 
 test('lists conversations from the API, most recent first', async () => {
-	renderInbox()
+	renderAt('/')
 
 	expect(await screen.findByText('John Doe')).toBeInTheDocument()
 	expect(screen.getByText('María Pérez')).toBeInTheDocument()
@@ -37,7 +25,7 @@ test('shows an empty state when no conversations exist', async () => {
 		),
 	)
 
-	renderInbox()
+	renderAt('/')
 
 	expect(await screen.findByText(/no conversations yet/i)).toBeInTheDocument()
 })
@@ -49,7 +37,7 @@ test('reports when conversations cannot be loaded', async () => {
 		),
 	)
 
-	renderInbox()
+	renderAt('/')
 
 	expect(await screen.findByText(/could not be loaded/i)).toBeInTheDocument()
 })

--- a/frontend/src/inbox/Inbox.tsx
+++ b/frontend/src/inbox/Inbox.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { useQuery } from '@tanstack/react-query'
+import { Link } from '@tanstack/react-router'
 
 import { fetchConversations } from '../api/whatsapp'
 import { Badge, Text } from '../ui'
@@ -24,7 +25,12 @@ export function Inbox() {
 		<ul>
 			{conversations.data.map((conversation) => (
 				<li key={conversation.id}>
-					<Text>{conversation.contact_name}</Text>
+					<Link
+						to="/conversations/$conversationId"
+						params={{ conversationId: conversation.id }}
+					>
+						{conversation.contact_name}
+					</Link>
 					<Badge>{conversation.status}</Badge>
 				</li>
 			))}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider } from '@tanstack/react-router'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
 import '@wordpress/theme/design-tokens.css'
 import './index.css'
-import { Inbox } from './inbox/Inbox'
+import { createAppRouter } from './router'
 import { ThemeProvider } from './ui'
 
 const queryClient = new QueryClient()
+const router = createAppRouter()
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
 		<QueryClientProvider client={queryClient}>
 			<ThemeProvider isRoot>
-				<Inbox />
+				<RouterProvider router={router} />
 			</ThemeProvider>
 		</QueryClientProvider>
 	</StrictMode>,

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, test } from 'vitest'
+
+import { renderAt } from './test/render'
+
+test('serves the inbox at the root path', async () => {
+	renderAt('/')
+
+	expect(await screen.findByText('John Doe')).toBeInTheDocument()
+})
+
+test('serves the thread for a conversation URL', async () => {
+	renderAt('/conversations/019f4a00-0000-7000-8000-000000000001')
+
+	expect(
+		await screen.findByText('Hi, is the order ready?'),
+	).toBeInTheDocument()
+})
+
+test('navigates from a conversation in the inbox to its thread', async () => {
+	const user = userEvent.setup()
+	renderAt('/')
+
+	await user.click(await screen.findByRole('link', { name: 'John Doe' }))
+
+	expect(
+		await screen.findByText('I can pick it up after 5pm.'),
+	).toBeInTheDocument()
+})
+
+test('shows the AlphOne masthead as a heading on every screen', async () => {
+	renderAt('/conversations/019f4a00-0000-7000-8000-000000000001')
+
+	expect(
+		await screen.findByRole('heading', { name: 'AlphOne' }),
+	).toBeInTheDocument()
+})
+
+test('returns to the inbox through the masthead link', async () => {
+	const user = userEvent.setup()
+	renderAt('/conversations/019f4a00-0000-7000-8000-000000000001')
+	await screen.findByText('Hi, is the order ready?')
+
+	await user.click(screen.getByRole('link', { name: 'AlphOne' }))
+
+	expect(await screen.findByText('María Pérez')).toBeInTheDocument()
+})

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import {
+	createRootRoute,
+	createRoute,
+	createRouter,
+} from '@tanstack/react-router'
+import type { RouterHistory } from '@tanstack/react-router'
+
+import { Layout } from './Layout'
+import { Inbox } from './inbox/Inbox'
+import { ThreadScreen } from './thread/ThreadScreen'
+
+const rootRoute = createRootRoute({
+	component: Layout,
+})
+
+const inboxRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: '/',
+	component: Inbox,
+})
+
+const threadRoute = createRoute({
+	getParentRoute: () => rootRoute,
+	path: '/conversations/$conversationId',
+	component: ThreadScreen,
+})
+
+const routeTree = rootRoute.addChildren([inboxRoute, threadRoute])
+
+export function createAppRouter(history?: RouterHistory) {
+	return createRouter({ routeTree, history })
+}
+
+declare module '@tanstack/react-router' {
+	interface Register {
+		router: ReturnType<typeof createAppRouter>
+	}
+}

--- a/frontend/src/test/render.tsx
+++ b/frontend/src/test/render.tsx
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RouterProvider, createMemoryHistory } from '@tanstack/react-router'
+import { render } from '@testing-library/react'
+
+import { createAppRouter } from '../router'
+
+export function renderAt(path: string) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	})
+	const router = createAppRouter(
+		createMemoryHistory({ initialEntries: [path] }),
+	)
+	render(
+		<QueryClientProvider client={client}>
+			<RouterProvider router={router} />
+		</QueryClientProvider>,
+	)
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
 import { HttpResponse, http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll } from 'vitest'
+import { afterAll, afterEach, beforeAll, vi } from 'vitest'
+
+vi.stubGlobal('scrollTo', () => {})
+
+afterEach(() => cleanup())
 
 export const server = setupServer(
 	http.get('/api/plugins/whatsapp/conversations', () =>
@@ -23,6 +28,26 @@ export const server = setupServer(
 				external_id: '184467235',
 				status: 'open',
 				last_activity_at: '2026-07-06T10:00:00Z',
+			},
+		]),
+	),
+	http.get('/api/plugins/whatsapp/conversations/:conversationId/messages', () =>
+		HttpResponse.json([
+			{
+				id: '019f4a00-0000-7000-8000-0000000000b1',
+				external_id: 'wamid.HBgLMTU1NTAwMDExMQ',
+				direction: 'inbound',
+				content: 'Hi, is the order ready?',
+				content_type: 'text',
+				sent_at: '2026-07-06T10:00:00Z',
+			},
+			{
+				id: '019f4a00-0000-7000-8000-0000000000b2',
+				external_id: 'wamid.HBgLMTU1NTAwMDExMg',
+				direction: 'inbound',
+				content: 'I can pick it up after 5pm.',
+				content_type: 'text',
+				sent_at: '2026-07-06T10:05:00Z',
 			},
 		]),
 	),

--- a/frontend/src/thread/Thread.test.tsx
+++ b/frontend/src/thread/Thread.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
+import { expect, test } from 'vitest'
+
+import { server } from '../test/setup'
+import { Thread } from './Thread'
+
+function renderThread() {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	})
+	render(
+		<QueryClientProvider client={client}>
+			<Thread conversationId="019f4a00-0000-7000-8000-000000000001" />
+		</QueryClientProvider>,
+	)
+}
+
+test('lists the conversation messages, oldest first', async () => {
+	renderThread()
+
+	expect(
+		await screen.findByText('Hi, is the order ready?'),
+	).toBeInTheDocument()
+	expect(screen.getByText('I can pick it up after 5pm.')).toBeInTheDocument()
+
+	const contents = screen
+		.getAllByRole('listitem')
+		.map((item) => item.textContent)
+	expect(contents[0]).toContain('Hi, is the order ready?')
+	expect(contents[1]).toContain('I can pick it up after 5pm.')
+
+	expect(screen.getAllByText('inbound')).toHaveLength(2)
+})
+
+test('shows an empty state when the conversation has no messages', async () => {
+	server.use(
+		http.get(
+			'/api/plugins/whatsapp/conversations/:conversationId/messages',
+			() => HttpResponse.json([]),
+		),
+	)
+
+	renderThread()
+
+	expect(await screen.findByText(/no messages yet/i)).toBeInTheDocument()
+})
+
+test('reports when messages cannot be loaded', async () => {
+	server.use(
+		http.get(
+			'/api/plugins/whatsapp/conversations/:conversationId/messages',
+			() => HttpResponse.json({ error: 'internal error' }, { status: 500 }),
+		),
+	)
+
+	renderThread()
+
+	expect(await screen.findByText(/could not be loaded/i)).toBeInTheDocument()
+})

--- a/frontend/src/thread/Thread.tsx
+++ b/frontend/src/thread/Thread.tsx
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useQuery } from '@tanstack/react-query'
+
+import { fetchMessages } from '../api/whatsapp'
+import { Badge, Text } from '../ui'
+
+export function Thread({ conversationId }: { conversationId: string }) {
+	const messages = useQuery({
+		queryKey: ['whatsapp', 'messages', conversationId],
+		queryFn: () => fetchMessages(conversationId),
+	})
+
+	if (messages.isPending) {
+		return <Text>Loading messages…</Text>
+	}
+	if (messages.isError) {
+		return <Text>Messages could not be loaded.</Text>
+	}
+	if (messages.data.length === 0) {
+		return <Text>No messages yet.</Text>
+	}
+	return (
+		<ul>
+			{messages.data.map((message) => (
+				<li key={message.id}>
+					<Text>{message.content}</Text>
+					<Badge>{message.direction}</Badge>
+				</li>
+			))}
+		</ul>
+	)
+}

--- a/frontend/src/thread/ThreadScreen.tsx
+++ b/frontend/src/thread/ThreadScreen.tsx
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { useParams } from '@tanstack/react-router'
+
+import { Thread } from './Thread'
+
+export function ThreadScreen() {
+	const { conversationId } = useParams({
+		from: '/conversations/$conversationId',
+	})
+	return <Thread conversationId={conversationId} />
+}


### PR DESCRIPTION
## Summary

Adds client-side routing and the conversation thread view: the inbox now links into a per-conversation message screen, with deep-linking support. 

- **TanStack Router** with code-based route declarations: inbox at `/`, thread at `/conversations/$conversationId`. Code-based (no codegen) was chosen deliberately: routes are plain values, so plugins can eventually contribute route objects at the composition root, mirroring how backend plugins provide handlers to the plugin host.
- **Thread view** fetches `GET /api/plugins/whatsapp/conversations/{id}/messages` via TanStack Query with zod validation at the boundary, and renders pending / error / empty / list states plus a direction badge per message.
- `createAppRouter` is a factory: tests inject `createMemoryHistory`, `main.tsx` uses browser history. The `Register` module augmentation makes `Link to` targets and `useParams` compile-time checked.