### PR TITLE
feat: map a spreadsheet column onto a field for Importer plugin

### DIFF
--- a/cmd/alphone/main_exec_test.go
+++ b/cmd/alphone/main_exec_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"os/exec"
@@ -260,6 +261,16 @@ type graphAnswer struct {
 		CreateContact struct {
 			ID string `json:"id"`
 		} `json:"createContact"`
+		ImportUpload struct {
+			ID string `json:"id"`
+		} `json:"importUpload"`
+		ImportCommit struct {
+			Imported int `json:"imported"`
+			Failed   int `json:"failed"`
+		} `json:"importCommit"`
+		ImportFields []struct {
+			Name string `json:"name"`
+		} `json:"importFields"`
 		Contacts *struct {
 			Edges []struct {
 				Node map[string]any `json:"node"`
@@ -303,11 +314,70 @@ func postGraph(t *testing.T, addr, secret, body string) graphAnswer {
 	return envelope
 }
 
-func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
-	t.Parallel()
+// uploadCSV posts one CSV file through the graph multipart upload protocol.
+func uploadCSV(t *testing.T, addr, secret, content string) graphAnswer {
+	t.Helper()
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	const operations = `{"query":"mutation($file: Upload!) { importUpload(file: $file) { id } }",` +
+		`"variables":{"file":null}}`
+	for field, value := range map[string]string{
+		"operations": operations,
+		"map":        `{"0":["variables.file"]}`,
+	} {
+		if err := form.WriteField(field, value); err != nil {
+			t.Fatalf("writing the %s part: %v", field, err)
+		}
+	}
+	part, err := form.CreateFormFile("0", "leads.csv")
+	if err != nil {
+		t.Fatalf("creating the file part: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("writing the file part: %v", err)
+	}
+	if err := form.Close(); err != nil {
+		t.Fatalf("closing the form: %v", err)
+	}
+	return postForm(t, addr, secret, form.FormDataContentType(), &body)
+}
 
+// postForm posts a multipart body to the graph, refusing any failure.
+func postForm(t *testing.T, addr, secret, contentType string, body io.Reader) graphAnswer {
+	t.Helper()
+	request, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost, "http://"+addr+"/api/graphql", body)
+	if err != nil {
+		t.Fatalf("building the upload request: %v", err)
+	}
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("Authorization", "Bearer "+secret)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("posting the upload: %v", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	answered, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("reading the upload answer: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d, answered %s", response.StatusCode, http.StatusOK, answered)
+	}
+	var envelope graphAnswer
+	if err := json.Unmarshal(answered, &envelope); err != nil {
+		t.Fatalf("decoding %s: %v", answered, err)
+	}
+	if len(envelope.Errors) > 0 {
+		t.Fatalf("the graph refused the upload: %s", answered)
+	}
+	return envelope
+}
+
+// servedBinary starts the real binary on its own database, answering its address and token.
+func servedBinary(t *testing.T, databaseURL string) (string, string) {
+	t.Helper()
 	binary, env := coverBinary(t)
-	databaseURL := testDatabaseURL(t)
 	createUser := exec.Command(binary, "createadmin", "-email", "admin@example.com", "-name", "Admin")
 	createUser.Dir = t.TempDir()
 	createUser.Env = append(env, "ALPHONE_DATABASE_URL="+databaseURL)
@@ -316,14 +386,13 @@ func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
 		t.Fatalf("createadmin: %v", err)
 	}
 	var minted bytes.Buffer
-	token := exec.Command(binary, "token", "create", "-email", "admin@example.com", "-name", "fields")
+	token := exec.Command(binary, "token", "create", "-email", "admin@example.com", "-name", "exec")
 	token.Dir = t.TempDir()
 	token.Env = append(env, "ALPHONE_DATABASE_URL="+databaseURL)
 	token.Stdout = &minted
 	if err := token.Run(); err != nil {
 		t.Fatalf("token create: %v", err)
 	}
-	secret := tokenSecret(t, minted.String())
 	addr := freeAddr(t)
 	serve := exec.Command(binary)
 	serve.Dir = t.TempDir()
@@ -338,6 +407,13 @@ func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = serve.Process.Kill() })
 	waitForServer(t, "http://"+addr)
+	return addr, tokenSecret(t, minted.String())
+}
+
+func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
+	t.Parallel()
+
+	addr, secret := servedBinary(t, testDatabaseURL(t))
 
 	defined := postGraph(t, addr, secret,
 		`{"query":"mutation { defineField(name: \"birthDate\", label: \"Birth date\", kind: DATE) { id } }"}`)
@@ -362,6 +438,49 @@ func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
 	node := read.Data.Contacts.Edges[0].Node
 	if _, selected := node["birthDate"]; !selected {
 		t.Errorf("node = %v, want birthDate answered by the running binary's widened schema", node)
+	}
+}
+
+func TestMainBinaryImportsASpreadsheetColumnIntoAField(t *testing.T) {
+	t.Parallel()
+
+	addr, secret := servedBinary(t, testDatabaseURL(t))
+	postGraph(t, addr, secret,
+		`{"query":"mutation { defineField(name: \"birthDate\", label: \"Birth date\", kind: DATE) { id } }"}`)
+
+	listed := postGraph(t, addr, secret, `{"query":"{ importFields { name } }"}`)
+	var mappable bool
+	for _, field := range listed.Data.ImportFields {
+		mappable = mappable || field.Name == "birthDate"
+	}
+	if !mappable {
+		t.Fatalf("importFields = %v, want the defined field mappable in the real binary", listed.Data.ImportFields)
+	}
+
+	uploaded := uploadCSV(t, addr, secret,
+		"Name,Email,Birth date\nMaria Perez,maria@example.com,1990-04-17\n")
+	if uploaded.Data.ImportUpload.ID == "" {
+		t.Fatal("importUpload answered no id, want the spreadsheet staged")
+	}
+	postGraph(t, addr, secret, `{"query":"mutation { importSetMapping(id: \"`+uploaded.Data.ImportUpload.ID+
+		`\", assignments: [{column: 0, field: \"name\"}, {column: 1, field: \"email\"},`+
+		` {column: 2, field: \"birthDate\"}]) { id } }"}`)
+	committed := postGraph(t, addr, secret,
+		`{"query":"mutation { importCommit(id: \"`+uploaded.Data.ImportUpload.ID+
+			`\") { imported failed } }"}`)
+
+	if committed.Data.ImportCommit.Imported != 1 {
+		t.Fatalf("imported = %d, failed = %d, want the row imported",
+			committed.Data.ImportCommit.Imported, committed.Data.ImportCommit.Failed)
+	}
+	read := postGraph(t, addr, secret,
+		`{"query":"{ contacts(first: 5) { edges { node { name birthDate } } } }"}`)
+	if read.Data.Contacts == nil || len(read.Data.Contacts.Edges) == 0 {
+		t.Fatal("the read answered no contacts, want the imported contact")
+	}
+	node := read.Data.Contacts.Edges[0].Node
+	if node["birthDate"] != "1990-04-17" {
+		t.Errorf("birthDate = %#v, want the imported cell served by the real binary", node["birthDate"])
 	}
 }
 

--- a/cmd/alphone/main_exec_test.go
+++ b/cmd/alphone/main_exec_test.go
@@ -184,6 +184,43 @@ func TestMainBinarySeedStoresDemoData(t *testing.T) {
 	}
 }
 
+func TestMainBinarySeedFillsTheDemoImportField(t *testing.T) {
+	t.Parallel()
+
+	binary, env := coverBinary(t)
+	databaseURL := testDatabaseURL(t)
+	var stderr bytes.Buffer
+	seedCmd := exec.Command(binary, "seed")
+	seedCmd.Dir = t.TempDir()
+	seedCmd.Env = append(env, "ALPHONE_DATABASE_URL="+databaseURL)
+	seedCmd.Stderr = &stderr
+	if err := seedCmd.Run(); err != nil {
+		t.Fatalf("seed: %v, stderr: %s", err, stderr.String())
+	}
+	addr, secret := servedSeededBinary(t, databaseURL)
+
+	read := postGraph(t, addr, secret,
+		`{"query":"{ contacts(first: 50) { edges { node { name birthDate } } } }"}`)
+
+	if read.Data.Contacts == nil {
+		t.Fatal("the read answered no contacts, want the seeded demo import")
+	}
+	var found bool
+	for _, edge := range read.Data.Contacts.Edges {
+		if edge.Node["name"] != "Grace Hopper" {
+			continue
+		}
+		found = true
+		if edge.Node["birthDate"] != "1906-12-09" {
+			t.Errorf("birthDate = %#v, want the value the seed path's providers wrote",
+				edge.Node["birthDate"])
+		}
+	}
+	if !found {
+		t.Error("the seeded demo import listed no Grace Hopper, want the imported contact")
+	}
+}
+
 func TestMainBinaryServesUntilSignalled(t *testing.T) {
 	t.Parallel()
 
@@ -385,6 +422,13 @@ func servedBinary(t *testing.T, databaseURL string) (string, string) {
 	if err := createUser.Run(); err != nil {
 		t.Fatalf("createadmin: %v", err)
 	}
+	return servedSeededBinary(t, databaseURL)
+}
+
+// servedSeededBinary starts the real binary on a database already holding the admin.
+func servedSeededBinary(t *testing.T, databaseURL string) (string, string) {
+	t.Helper()
+	binary, env := coverBinary(t)
 	var minted bytes.Buffer
 	token := exec.Command(binary, "token", "create", "-email", "admin@example.com", "-name", "exec")
 	token.Dir = t.TempDir()

--- a/cmd/alphone/run.go
+++ b/cmd/alphone/run.go
@@ -81,6 +81,7 @@ func run(
 	if err != nil {
 		return fmt.Errorf("register plugins: %w", err)
 	}
+	wireFieldProviders(registered)
 
 	host := pluginkit.NewHost(registered...)
 	if err := host.Start(ctx); err != nil {
@@ -139,6 +140,21 @@ func fieldSources(registered []sdk.Plugin) []sdk.FieldSource {
 		}
 	}
 	return sources
+}
+
+// wireFieldProviders hands every registered field provider to every consumer.
+func wireFieldProviders(registered []sdk.Plugin) {
+	var providers []sdk.FieldProvider
+	for _, plugin := range registered {
+		if provider, ok := plugin.(sdk.FieldProvider); ok {
+			providers = append(providers, provider)
+		}
+	}
+	for _, plugin := range registered {
+		if consumer, ok := plugin.(sdk.FieldConsumer); ok {
+			consumer.UseFieldProviders(providers)
+		}
+	}
 }
 
 // runConfig carries the environment-derived settings of the server.

--- a/cmd/alphone/seed.go
+++ b/cmd/alphone/seed.go
@@ -180,6 +180,7 @@ func seedPlugins(
 	if err != nil {
 		return err
 	}
+	wireFieldProviders(registered)
 	host := pluginkit.NewHost(registered...)
 	defer func() { _ = host.Stop(context.WithoutCancel(ctx)) }()
 	if err := host.Start(ctx); err != nil {

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,7 @@
 services:
   postgres:
     image: postgres:18
+    command: ["postgres", "-c", "max_connections=300"]
     environment:
       POSTGRES_PASSWORD: alphone
     ports:

--- a/docs/src/content/docs/guides/automation.md
+++ b/docs/src/content/docs/guides/automation.md
@@ -197,6 +197,10 @@ Importing a spreadsheet of contacts is only half the job. The work is
 calling them, and a thousand new contacts is not a thousand tasks for
 today. This recipe spreads them over as many days as it takes.
 
+A spreadsheet column can also fill a field you defined yourself, so the
+contacts arrive with a birth date or a loyalty score already on them. See
+[Fields](/guides/fields/).
+
 Subscribe to `import.completed`. It carries the import `id`, so the next
 step reads what that import produced:
 

--- a/docs/src/content/docs/guides/fields.md
+++ b/docs/src/content/docs/guides/fields.md
@@ -41,6 +41,23 @@ input per field you created. Type, then press **Save fields**.
 A field you never fill in stays empty. AlphOne stores nothing for it and it
 costs nothing.
 
+## Fill a field from a spreadsheet
+
+You do not have to type every value in by hand. When you import a CSV or an
+Excel file, your fields sit in the mapping dropdown beside Name, Email and
+Phone. Point a column at one and the values arrive with the contacts.
+
+The kind is checked before anything is stored. A row whose cell does not fit
+its field fails, the reason names the field and its kind, and no contact is
+created for that row. Fix the spreadsheet and import it again.
+
+An empty cell stores nothing. The contact is created and the field stays
+waiting, exactly as if you had never touched it.
+
+One thing an import will not do is change a contact you already have. A row
+matching an existing contact is skipped, and its fields are left alone. That
+keeps an import from quietly overwriting work.
+
 ## The kind is checked when you save
 
 AlphOne refuses a value that does not match the kind. A `Date` field will not

--- a/plugins/fields/provider.go
+++ b/plugins/fields/provider.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package fields
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/alphone/sdk"
+)
+
+// booleanTexts maps every text a boolean field accepts to the value it stores.
+var booleanTexts = map[string]bool{
+	"true": true, "yes": true, "1": true,
+	"false": false, "no": false, "0": false,
+}
+
+// LiveContactFields lists every field a column may be mapped onto.
+func (p *Plugin) LiveContactFields(ctx context.Context) ([]sdk.ContactField, error) {
+	definitions, err := p.store.liveDefinitions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	listed := make([]sdk.ContactField, 0, len(definitions))
+	for _, definition := range definitions {
+		listed = append(listed, sdk.ContactField{Name: definition.Name, Label: definition.Label})
+	}
+	return listed, nil
+}
+
+// CheckContactFieldTexts reports whether every text fits the kind its definition declares.
+func (p *Plugin) CheckContactFieldTexts(_ context.Context, values map[string]string) error {
+	_, err := p.readTexts(values)
+	return err
+}
+
+// WriteContactFieldTexts stores the values the texts describe on one contact.
+func (p *Plugin) WriteContactFieldTexts(
+	ctx context.Context, contactID uuid.UUID, values map[string]string,
+) error {
+	read, err := p.readTexts(values)
+	if err != nil {
+		return err
+	}
+	if len(read) == 0 {
+		return nil
+	}
+	return p.store.writeValues(ctx, contactID, read)
+}
+
+// readTexts returns the storable values the texts describe, refusing the rest.
+func (p *Plugin) readTexts(values map[string]string) (map[string]any, error) {
+	live := p.catalog.liveKinds()
+	given := make(map[string]any, len(values))
+	for name, text := range values {
+		trimmed := strings.TrimSpace(text)
+		if trimmed == "" {
+			continue
+		}
+		given[name] = typedText(live[name], trimmed)
+	}
+	checked, err := checkValues(live, given)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", sdk.ErrInvalidFieldText, err)
+	}
+	return checked, nil
+}
+
+// typedText reads text as the value its kind holds, leaving the rest as written.
+func typedText(held kind, text string) any {
+	switch held {
+	case kindNumber:
+		if _, err := strconv.ParseInt(text, 10, 64); err == nil {
+			return json.Number(text)
+		}
+	case kindBoolean:
+		if flag, known := booleanTexts[strings.ToLower(text)]; known {
+			return flag
+		}
+	case kindText, kindLongText, kindSelect, kindDate:
+	}
+	return text
+}

--- a/plugins/fields/provider_internal_test.go
+++ b/plugins/fields/provider_internal_test.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package fields
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/alphone/sdk"
+)
+
+var _ sdk.FieldProvider = (*Plugin)(nil)
+
+// labelled builds a live definition carrying a chosen label.
+func labelled(t *testing.T, name, label, declared string) Definition {
+	t.Helper()
+	definition, err := newDefinition(name, label, declared, nil)
+	if err != nil {
+		t.Fatalf("newDefinition(%q) error = %v, want nil", name, err)
+	}
+	return definition
+}
+
+// define stores a definition and reloads the catalogue behind it.
+func define(t *testing.T, p *Plugin, definition Definition) {
+	t.Helper()
+	if err := p.store.define(t.Context(), definition); err != nil {
+		t.Fatalf("define(%q) error = %v, want nil", definition.Name, err)
+	}
+	if err := p.catalog.reload(t.Context()); err != nil {
+		t.Fatalf("reload() error = %v, want nil", err)
+	}
+}
+
+func TestTypedTextReadsTheValueItsKindHolds(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		kind kind
+		text string
+		want any
+	}{
+		"text":            {kindText, "Maria Perez", "Maria Perez"},
+		"long text":       {kindLongText, "a longer note", "a longer note"},
+		"select":          {kindSelect, "home", "home"},
+		"date":            {kindDate, "1990-04-17", "1990-04-17"},
+		"number":          {kindNumber, "420", json.Number("420")},
+		"negative number": {kindNumber, "-7", json.Number("-7")},
+		"signed number":   {kindNumber, "+7", json.Number("+7")},
+		"boolean true":    {kindBoolean, "true", true},
+		"boolean yes":     {kindBoolean, "yes", true},
+		"boolean one":     {kindBoolean, "1", true},
+		"boolean false":   {kindBoolean, "false", false},
+		"boolean no":      {kindBoolean, "no", false},
+		"boolean zero":    {kindBoolean, "0", false},
+		"boolean upper":   {kindBoolean, "YES", true},
+		"boolean mixed":   {kindBoolean, "No", false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := typedText(tc.kind, tc.text); got != tc.want {
+				t.Errorf("typedText(%s, %q) = %#v, want %#v", tc.kind, tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypedTextLeavesUnreadableTextAsWritten(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		kind kind
+		text string
+	}{
+		"number given words":              {kindNumber, "four hundred"},
+		"number given a fraction":         {kindNumber, "4.5"},
+		"number given scientific writing": {kindNumber, "1e5"},
+		"number given a stray comma":      {kindNumber, "1,000"},
+		"boolean given words":             {kindBoolean, "maybe"},
+		"boolean given a number":          {kindBoolean, "2"},
+		"an unknown kind":                 {kind("TIMESTAMP"), "1990-04-17"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := typedText(tc.kind, tc.text); got != tc.text {
+				t.Errorf("typedText(%s, %q) = %#v, want the text left for coerce to refuse", tc.kind, tc.text, got)
+			}
+		})
+	}
+}
+
+func TestLiveContactFieldsListsEveryNameWithItsLabel(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	define(t, p, labelled(t, "loyaltyPoints", "Loyalty points", "NUMBER"))
+
+	listed, err := p.LiveContactFields(t.Context())
+
+	if err != nil {
+		t.Fatalf("LiveContactFields() error = %v, want nil", err)
+	}
+	want := map[string]string{"birthDate": "Birth date", "loyaltyPoints": "Loyalty points"}
+	if len(listed) != len(want) {
+		t.Fatalf("listed = %d fields, want %d", len(listed), len(want))
+	}
+	for _, field := range listed {
+		if want[field.Name] != field.Label {
+			t.Errorf("%s is labelled %q, want %q", field.Name, field.Label, want[field.Name])
+		}
+	}
+}
+
+func TestLiveContactFieldsLeavesOutAnArchivedField(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	definition := labelled(t, "birthDate", "Birth date", "DATE")
+	define(t, p, definition)
+	if err := p.store.archive(t.Context(), definition.ID); err != nil {
+		t.Fatalf("archive() error = %v, want nil", err)
+	}
+
+	listed, err := p.LiveContactFields(t.Context())
+
+	if err != nil {
+		t.Fatalf("LiveContactFields() error = %v, want nil", err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("listed = %#v, want the archived field left out", listed)
+	}
+}
+
+func TestLiveContactFieldsReportsAReadFailure(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	if err := p.Stop(t.Context()); err != nil {
+		t.Fatalf("Stop() error = %v, want nil", err)
+	}
+
+	if _, err := p.LiveContactFields(t.Context()); err == nil {
+		t.Error("LiveContactFields() error = nil, want the unreadable catalogue reported")
+	}
+}
+
+func TestWriteContactFieldTextsStoresTheValueEachKindHolds(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	define(t, p, labelled(t, "loyaltyPoints", "Loyalty points", "NUMBER"))
+	define(t, p, labelled(t, "subscribed", "Subscribed", "BOOLEAN"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{
+		"birthDate": "1990-04-17", "loyaltyPoints": "420", "subscribed": "yes",
+	})
+
+	if err != nil {
+		t.Fatalf("WriteContactFieldTexts() error = %v, want nil", err)
+	}
+	held, err := p.store.valuesFor(t.Context(), []uuid.UUID{maria})
+	if err != nil {
+		t.Fatalf("valuesFor() error = %v, want nil", err)
+	}
+	values := held[maria]
+	if values["birthDate"] != "1990-04-17" {
+		t.Errorf("birthDate = %#v, want the written date", values["birthDate"])
+	}
+	if values["loyaltyPoints"] != float64(420) {
+		t.Errorf("loyaltyPoints = %#v, want the number stored", values["loyaltyPoints"])
+	}
+	if values["subscribed"] != true {
+		t.Errorf("subscribed = %#v, want true", values["subscribed"])
+	}
+}
+
+func TestWriteContactFieldTextsTrimsBeforeReading(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "loyaltyPoints", "Loyalty points", "NUMBER"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{"loyaltyPoints": "  420  "})
+
+	if err != nil {
+		t.Fatalf("WriteContactFieldTexts() error = %v, want nil", err)
+	}
+	held, err := p.store.valuesFor(t.Context(), []uuid.UUID{maria})
+	if err != nil {
+		t.Fatalf("valuesFor() error = %v, want nil", err)
+	}
+	if held[maria]["loyaltyPoints"] != float64(420) {
+		t.Errorf("loyaltyPoints = %#v, want the trimmed number", held[maria]["loyaltyPoints"])
+	}
+}
+
+func TestWriteContactFieldTextsLeavesAnEmptyTextUnwritten(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{"birthDate": "   "})
+
+	if err != nil {
+		t.Fatalf("WriteContactFieldTexts() error = %v, want nil", err)
+	}
+	held, err := p.store.valuesFor(t.Context(), []uuid.UUID{maria})
+	if err != nil {
+		t.Fatalf("valuesFor() error = %v, want nil", err)
+	}
+	if _, written := held[maria]["birthDate"]; written {
+		t.Errorf("values = %#v, want an empty text to store nothing", held[maria])
+	}
+}
+
+func TestWriteContactFieldTextsRefusesATextOfAnotherKind(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{"birthDate": "not a date"})
+
+	if !errors.Is(err, sdk.ErrInvalidFieldText) {
+		t.Fatalf("error = %v, want sdk.ErrInvalidFieldText", err)
+	}
+	for _, want := range []string{"birthDate", "DATE"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %v, want it to name %q", err, want)
+		}
+	}
+}
+
+func TestWriteContactFieldTextsRefusesANumberTheScalarCannotHold(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "loyaltyPoints", "Loyalty points", "NUMBER"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{"loyaltyPoints": "2147483648"})
+
+	if !errors.Is(err, sdk.ErrInvalidFieldText) {
+		t.Errorf("error = %v, want the Int ceiling enforced through coerce", err)
+	}
+}
+
+func TestWriteContactFieldTextsRefusesANameNoFieldHolds(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.WriteContactFieldTexts(t.Context(), maria, map[string]string{"neverDefined": "x"})
+
+	if !errors.Is(err, sdk.ErrInvalidFieldText) {
+		t.Fatalf("error = %v, want sdk.ErrInvalidFieldText", err)
+	}
+	if !strings.Contains(err.Error(), "neverDefined") {
+		t.Errorf("error = %v, want it to name the undefined field", err)
+	}
+}
+
+func TestWriteContactFieldTextsWritesNothingWhenEveryTextIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	if err := p.Stop(t.Context()); err != nil {
+		t.Fatalf("Stop() error = %v, want nil", err)
+	}
+
+	err := p.WriteContactFieldTexts(t.Context(), uuid.Must(uuid.NewV7()), map[string]string{"birthDate": ""})
+
+	if err != nil {
+		t.Errorf("error = %v, want no store call for an empty text", err)
+	}
+}
+
+func TestCheckContactFieldTextsRefusesWithoutWriting(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	maria := seedContact(t, p, "Maria Perez")
+
+	err := p.CheckContactFieldTexts(t.Context(), map[string]string{"birthDate": "not a date"})
+
+	if !errors.Is(err, sdk.ErrInvalidFieldText) {
+		t.Fatalf("error = %v, want sdk.ErrInvalidFieldText", err)
+	}
+	held, err := p.store.valuesFor(t.Context(), []uuid.UUID{maria})
+	if err != nil {
+		t.Fatalf("valuesFor() error = %v, want nil", err)
+	}
+	if len(held) != 0 {
+		t.Errorf("values = %#v, want the check to store nothing", held)
+	}
+}
+
+func TestCheckContactFieldTextsAcceptsTextEveryKindHolds(t *testing.T) {
+	t.Parallel()
+
+	p := newMigratedPlugin(t)
+	define(t, p, labelled(t, "birthDate", "Birth date", "DATE"))
+	define(t, p, labelled(t, "loyaltyPoints", "Loyalty points", "NUMBER"))
+
+	err := p.CheckContactFieldTexts(t.Context(), map[string]string{
+		"birthDate": "1990-04-17", "loyaltyPoints": "420",
+	})
+
+	if err != nil {
+		t.Errorf("CheckContactFieldTexts() error = %v, want nil", err)
+	}
+}

--- a/plugins/importer/commit.go
+++ b/plugins/importer/commit.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -25,6 +26,7 @@ var errAlreadyCommitted = errors.New("the import is already committed")
 type draft struct {
 	name       string
 	identities []sdk.Identity
+	texts      map[string]string
 }
 
 // settlement is the outcome one staged row settles into.
@@ -35,13 +37,15 @@ type settlement struct {
 }
 
 // commitRows settles every row of the import still waiting to be committed.
-func (p *Plugin) commitRows(ctx context.Context, importID uuid.UUID, assigned mapping) error {
+func (p *Plugin) commitRows(
+	ctx context.Context, importID uuid.UUID, assigned mapping, known registry,
+) error {
 	pending, err := p.store.pendingRows(ctx, importID)
 	if err != nil {
 		return err
 	}
 	for _, row := range pending {
-		if err := p.commitRow(ctx, row, assigned); err != nil {
+		if err := p.commitRow(ctx, row, assigned, known); err != nil {
 			return err
 		}
 	}
@@ -49,8 +53,10 @@ func (p *Plugin) commitRows(ctx context.Context, importID uuid.UUID, assigned ma
 }
 
 // commitRow settles one staged row, recording details the host refuses as a failure.
-func (p *Plugin) commitRow(ctx context.Context, staged stagedRow, assigned mapping) error {
-	settled, err := p.settle(ctx, draftOf(staged.Cells, assigned))
+func (p *Plugin) commitRow(
+	ctx context.Context, staged stagedRow, assigned mapping, known registry,
+) error {
+	settled, err := p.settle(ctx, draftOf(staged.Cells, assigned), known)
 	if errors.Is(err, sdk.ErrInvalidContact) {
 		settled, err = refused(), nil
 	}
@@ -69,9 +75,15 @@ func refused() settlement {
 }
 
 // settle turns one drafted contact into the outcome its row records.
-func (p *Plugin) settle(ctx context.Context, d draft) (settlement, error) {
+func (p *Plugin) settle(ctx context.Context, d draft, known registry) (settlement, error) {
 	if !d.usable() {
 		return settlement{outcome: outcomeFailed, reason: "the row carries no name or no contact detail"}, nil
+	}
+	if err := known.checkTexts(ctx, d.texts); err != nil {
+		if errors.Is(err, sdk.ErrInvalidFieldText) {
+			return refusedText(err), nil
+		}
+		return settlement{}, err
 	}
 	owner, claimed, err := p.claimant(ctx, d.identities)
 	if err != nil {
@@ -80,7 +92,15 @@ func (p *Plugin) settle(ctx context.Context, d draft) (settlement, error) {
 	if claimed {
 		return skipped(owner), nil
 	}
-	return p.create(ctx, d)
+	return p.create(ctx, d, known)
+}
+
+// refusedText returns the settlement of a row carrying a value no field accepts.
+func refusedText(err error) settlement {
+	return settlement{
+		outcome: outcomeFailed,
+		reason:  strings.TrimPrefix(err.Error(), sdk.ErrInvalidFieldText.Error()+": "),
+	}
 }
 
 // usable reports whether the draft carries enough to become a contact.
@@ -88,14 +108,17 @@ func (d draft) usable() bool {
 	return d.name != "" && len(d.identities) > 0
 }
 
-// create stores the drafted contact, reporting a lost race as a skip.
-func (p *Plugin) create(ctx context.Context, d draft) (settlement, error) {
+// create stores the drafted contact and its field values, reporting a lost race as a skip.
+func (p *Plugin) create(ctx context.Context, d draft, known registry) (settlement, error) {
 	created, wasCreated, err := p.contacts.CreateWithIdentities(ctx, d.name, d.identities)
 	if err != nil {
 		return settlement{}, err
 	}
 	if !wasCreated {
 		return skipped(created), nil
+	}
+	if err := known.writeTexts(ctx, created.ID, d.texts); err != nil {
+		return settlement{}, err
 	}
 	return settlement{outcome: outcomeImported, contactID: &created.ID}, nil
 }
@@ -132,13 +155,19 @@ func draftOf(cells []string, assigned mapping) draft {
 		if value == "" {
 			continue
 		}
-		if field == fieldContactName {
+		switch {
+		case field == fieldContactName:
 			d.name = value
-			continue
+		case core(field):
+			d.identities = append(d.identities, sdk.Identity{
+				Channel: sdk.Channel(field), Identifier: value,
+			})
+		default:
+			if d.texts == nil {
+				d.texts = map[string]string{}
+			}
+			d.texts[string(field)] = value
 		}
-		d.identities = append(d.identities, sdk.Identity{
-			Channel: sdk.Channel(field), Identifier: value,
-		})
 	}
 	return d
 }

--- a/plugins/importer/commit.go
+++ b/plugins/importer/commit.go
@@ -79,7 +79,11 @@ func (p *Plugin) settle(ctx context.Context, d draft, known registry) (settlemen
 	if !d.usable() {
 		return settlement{outcome: outcomeFailed, reason: "the row carries no name or no contact detail"}, nil
 	}
-	if err := known.checkTexts(ctx, d.texts); err != nil {
+	grouped, err := known.group(d.texts)
+	if err != nil {
+		return refusedText(err), nil
+	}
+	if err := known.check(ctx, grouped); err != nil {
 		if errors.Is(err, sdk.ErrInvalidFieldText) {
 			return refusedText(err), nil
 		}
@@ -92,7 +96,7 @@ func (p *Plugin) settle(ctx context.Context, d draft, known registry) (settlemen
 	if claimed {
 		return skipped(owner), nil
 	}
-	return p.create(ctx, d, known)
+	return p.create(ctx, d, known, grouped)
 }
 
 // refusedText returns the settlement of a row carrying a value no field accepts.
@@ -109,7 +113,9 @@ func (d draft) usable() bool {
 }
 
 // create stores the drafted contact and its field values, reporting a lost race as a skip.
-func (p *Plugin) create(ctx context.Context, d draft, known registry) (settlement, error) {
+func (p *Plugin) create(
+	ctx context.Context, d draft, known registry, grouped shares,
+) (settlement, error) {
 	created, wasCreated, err := p.contacts.CreateWithIdentities(ctx, d.name, d.identities)
 	if err != nil {
 		return settlement{}, err
@@ -117,7 +123,7 @@ func (p *Plugin) create(ctx context.Context, d draft, known registry) (settlemen
 	if !wasCreated {
 		return skipped(created), nil
 	}
-	if err := known.writeTexts(ctx, created.ID, d.texts); err != nil {
+	if err := known.write(ctx, created.ID, grouped); err != nil {
 		return settlement{}, err
 	}
 	return settlement{outcome: outcomeImported, contactID: &created.ID}, nil

--- a/plugins/importer/commit.go
+++ b/plugins/importer/commit.go
@@ -101,10 +101,22 @@ func (p *Plugin) settle(ctx context.Context, d draft, known registry) (settlemen
 
 // refusedText returns the settlement of a row carrying a value no field accepts.
 func refusedText(err error) settlement {
-	return settlement{
-		outcome: outcomeFailed,
-		reason:  strings.TrimPrefix(err.Error(), sdk.ErrInvalidFieldText.Error()+": "),
+	return settlement{outcome: outcomeFailed, reason: refusalDetail(err)}
+}
+
+// refusalDetail returns the half of a refusal naming what the row got wrong.
+func refusalDetail(err error) string {
+	var wrapped interface{ Unwrap() []error }
+	if errors.As(err, &wrapped) {
+		for _, held := range wrapped.Unwrap() {
+			if !errors.Is(held, sdk.ErrInvalidFieldText) {
+				return held.Error()
+			}
+		}
 	}
+	return strings.TrimSpace(strings.ReplaceAll(
+		strings.ReplaceAll(err.Error(), sdk.ErrInvalidFieldText.Error()+": ", ""),
+		sdk.ErrInvalidFieldText.Error(), ""))
 }
 
 // usable reports whether the draft carries enough to become a contact.

--- a/plugins/importer/fields.go
+++ b/plugins/importer/fields.go
@@ -2,6 +2,17 @@
 
 package importer
 
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/alphone/sdk"
+)
+
 // fieldName is a contact detail a column may be mapped onto.
 type fieldName string
 
@@ -19,19 +30,119 @@ type mappableField struct {
 	Required bool
 }
 
-// mappableFields lists every field a column may be mapped onto.
-var mappableFields = []mappableField{
+// coreFields lists the columns the importer serves without any provider.
+var coreFields = []mappableField{
 	{Name: fieldContactName, Label: "Name", Required: true},
 	{Name: fieldEmail, Label: "Email", Required: false},
 	{Name: fieldPhone, Label: "Phone", Required: false},
 }
 
-// mappable reports whether the registry carries the named field.
-func mappable(name fieldName) bool {
-	for _, field := range mappableFields {
-		if field.Name == name {
-			return true
+// core reports whether the name is one of the importer's own columns.
+func core(name fieldName) bool {
+	return slices.ContainsFunc(coreFields, func(field mappableField) bool {
+		return field.Name == name
+	})
+}
+
+// registry is the mappable registry beside the provider serving each field.
+type registry struct {
+	fields    []mappableField
+	owner     map[fieldName]int
+	providers []sdk.FieldProvider
+}
+
+// UseFieldProviders receives the providers serving runtime defined fields.
+func (p *Plugin) UseFieldProviders(providers []sdk.FieldProvider) {
+	p.providers = providers
+}
+
+// registry merges the core columns with every field the providers serve.
+func (p *Plugin) registry(ctx context.Context) (registry, error) {
+	held := registry{
+		fields:    slices.Clone(coreFields),
+		owner:     map[fieldName]int{},
+		providers: p.providers,
+	}
+	for index, provider := range p.providers {
+		listed, err := provider.LiveContactFields(ctx)
+		if err != nil {
+			return registry{}, err
+		}
+		for _, field := range listed {
+			held.add(fieldName(field.Name), field.Label, index)
 		}
 	}
-	return false
+	return held, nil
+}
+
+// add lists one provider served field unless its name is already claimed.
+func (r *registry) add(name fieldName, label string, index int) {
+	if core(name) {
+		return
+	}
+	if _, claimed := r.owner[name]; claimed {
+		return
+	}
+	r.owner[name] = index
+	r.fields = append(r.fields, mappableField{Name: name, Label: label})
+}
+
+// holds reports whether the registry carries the named field.
+func (r registry) holds(name fieldName) bool {
+	if core(name) {
+		return true
+	}
+	_, served := r.owner[name]
+	return served
+}
+
+// checkTexts reports whether every provider accepts the texts its own fields carry.
+func (r registry) checkTexts(ctx context.Context, texts map[string]string) error {
+	grouped, err := r.group(texts)
+	if err != nil {
+		return err
+	}
+	for index, held := range grouped {
+		if err := r.providers[index].CheckContactFieldTexts(ctx, held); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeTexts stores each text through the provider serving its field.
+func (r registry) writeTexts(ctx context.Context, contactID uuid.UUID, texts map[string]string) error {
+	grouped, err := r.group(texts)
+	if err != nil {
+		return err
+	}
+	for index, held := range grouped {
+		if err := r.providers[index].WriteContactFieldTexts(ctx, contactID, held); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// group sorts the texts by the provider serving each field, refusing the unserved.
+func (r registry) group(texts map[string]string) (map[int]map[string]string, error) {
+	grouped := make(map[int]map[string]string, len(texts))
+	var unserved []string
+	for name, text := range texts {
+		index, served := r.owner[fieldName(name)]
+		if !served {
+			unserved = append(unserved, name)
+			continue
+		}
+		if grouped[index] == nil {
+			grouped[index] = map[string]string{}
+		}
+		grouped[index][name] = text
+	}
+	if len(unserved) > 0 {
+		slices.Sort(unserved)
+		return nil, fmt.Errorf("%w: no live field holds %s",
+			sdk.ErrInvalidFieldText, strings.Join(unserved, ", "))
+	}
+	return grouped, nil
 }

--- a/plugins/importer/fields.go
+++ b/plugins/importer/fields.go
@@ -116,8 +116,8 @@ func (r registry) group(texts map[string]string) (shares, error) {
 	}
 	if len(unserved) > 0 {
 		slices.Sort(unserved)
-		return nil, fmt.Errorf("%w: no live field holds %s",
-			sdk.ErrInvalidFieldText, strings.Join(unserved, ", "))
+		return nil, fmt.Errorf("%w: %w", sdk.ErrInvalidFieldText,
+			fmt.Errorf("no live field holds %s", strings.Join(unserved, ", ")))
 	}
 	return grouped, nil
 }

--- a/plugins/importer/fields.go
+++ b/plugins/importer/fields.go
@@ -96,37 +96,12 @@ func (r registry) holds(name fieldName) bool {
 	return served
 }
 
-// checkTexts reports whether every provider accepts the texts its own fields carry.
-func (r registry) checkTexts(ctx context.Context, texts map[string]string) error {
-	grouped, err := r.group(texts)
-	if err != nil {
-		return err
-	}
-	for index, held := range grouped {
-		if err := r.providers[index].CheckContactFieldTexts(ctx, held); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// writeTexts stores each text through the provider serving its field.
-func (r registry) writeTexts(ctx context.Context, contactID uuid.UUID, texts map[string]string) error {
-	grouped, err := r.group(texts)
-	if err != nil {
-		return err
-	}
-	for index, held := range grouped {
-		if err := r.providers[index].WriteContactFieldTexts(ctx, contactID, held); err != nil {
-			return err
-		}
-	}
-	return nil
-}
+// shares is one row's field texts, keyed by the provider serving each field.
+type shares map[int]map[string]string
 
 // group sorts the texts by the provider serving each field, refusing the unserved.
-func (r registry) group(texts map[string]string) (map[int]map[string]string, error) {
-	grouped := make(map[int]map[string]string, len(texts))
+func (r registry) group(texts map[string]string) (shares, error) {
+	grouped := make(shares, len(texts))
 	var unserved []string
 	for name, text := range texts {
 		index, served := r.owner[fieldName(name)]
@@ -145,4 +120,33 @@ func (r registry) group(texts map[string]string) (map[int]map[string]string, err
 			sdk.ErrInvalidFieldText, strings.Join(unserved, ", "))
 	}
 	return grouped, nil
+}
+
+// check reports whether every provider accepts the share its own fields carry.
+func (r registry) check(ctx context.Context, grouped shares) error {
+	for index, held := range grouped {
+		if err := r.providers[index].CheckContactFieldTexts(ctx, held); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// write stores every share through the provider serving it.
+func (r registry) write(ctx context.Context, contactID uuid.UUID, grouped shares) error {
+	for index, held := range grouped {
+		if err := r.providers[index].WriteContactFieldTexts(ctx, contactID, held); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeOne stores one text through the provider serving its field, if any does.
+func (r registry) writeOne(ctx context.Context, contactID uuid.UUID, name, text string) error {
+	index, served := r.owner[fieldName(name)]
+	if !served {
+		return nil
+	}
+	return r.providers[index].WriteContactFieldTexts(ctx, contactID, map[string]string{name: text})
 }

--- a/plugins/importer/graphql.go
+++ b/plugins/importer/graphql.go
@@ -125,9 +125,13 @@ func (q QueryResolvers) ImportJob(ctx context.Context, id uuid.UUID) (*model.Imp
 }
 
 // ImportFields lists the fields a column may be mapped onto.
-func (q QueryResolvers) ImportFields(context.Context) ([]*model.ImportField, error) {
-	fields := make([]*model.ImportField, len(mappableFields))
-	for i, field := range mappableFields {
+func (q QueryResolvers) ImportFields(ctx context.Context) ([]*model.ImportField, error) {
+	known, err := q.plugin.registry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fields := make([]*model.ImportField, len(known.fields))
+	for i, field := range known.fields {
 		fields[i] = &model.ImportField{
 			Name:     string(field.Name),
 			Label:    field.Label,
@@ -228,7 +232,11 @@ func (m MutationResolvers) ImportSetMapping(
 	if stored.State != stateReady {
 		return nil, sdk.GraphError{Code: "CONFLICT", Err: errMappingLocked}
 	}
-	assigned, err := buildMapping(toAssignments(assignments), len(stored.Columns))
+	known, err := m.plugin.registry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	assigned, err := buildMapping(toAssignments(assignments), len(stored.Columns), known)
 	if err != nil {
 		return nil, sdk.GraphError{Code: "VALIDATION", Err: err}
 	}
@@ -256,11 +264,18 @@ func (m MutationResolvers) ImportCommit(
 	if err != nil {
 		return nil, err
 	}
+	known, err := m.plugin.registry(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkEntry(stored, known); err != nil {
+		return nil, sdk.GraphError{Code: "VALIDATION", Err: err}
+	}
 	claimed, err := m.plugin.store.claimForCommit(ctx, stored.ID)
 	if err != nil {
 		return nil, classifyClaimError(err)
 	}
-	if err := m.plugin.commitRows(ctx, stored.ID, claimed); err != nil {
+	if err := m.plugin.commitRows(ctx, stored.ID, claimed, known); err != nil {
 		return nil, err
 	}
 	counts, err := m.plugin.store.finishCommit(ctx, stored.ID)

--- a/plugins/importer/importer.go
+++ b/plugins/importer/importer.go
@@ -25,10 +25,11 @@ var migrationSource = mustSub(migrations, "migrations")
 
 // Plugin imports contacts from CSV and Excel files.
 type Plugin struct {
-	pool     *pgxpool.Pool
-	store    *store
-	contacts sdk.ContactDirectory
-	events   sdk.Publisher
+	pool      *pgxpool.Pool
+	store     *store
+	contacts  sdk.ContactDirectory
+	events    sdk.Publisher
+	providers []sdk.FieldProvider
 }
 
 // Register builds the importer [Plugin] from the host-provided deps.

--- a/plugins/importer/mapping.go
+++ b/plugins/importer/mapping.go
@@ -5,7 +5,9 @@ package importer
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 )
 
 // errRequiredFieldUnmapped reports assignments leaving a required field unclaimed.
@@ -21,11 +23,11 @@ type assignment struct {
 }
 
 // buildMapping turns assignments into the stored mapping, refusing an unusable set.
-func buildMapping(assignments []assignment, width int) (mapping, error) {
+func buildMapping(assignments []assignment, width int, known registry) (mapping, error) {
 	assigned := make(mapping, len(assignments))
 	claimed := make(map[fieldName]bool, len(assignments))
 	for _, one := range assignments {
-		if err := checkAssignment(one, width, assigned, claimed); err != nil {
+		if err := checkAssignment(one, width, assigned, claimed, known); err != nil {
 			return nil, err
 		}
 		assigned[strconv.Itoa(one.Column)] = one.Field
@@ -37,17 +39,38 @@ func buildMapping(assignments []assignment, width int) (mapping, error) {
 	return assigned, nil
 }
 
+// checkEntry refuses a ready import whose mapping names a field no registry holds.
+func checkEntry(stored importRow, known registry) error {
+	if stored.State != stateReady {
+		return nil
+	}
+	var vanished []string
+	for _, field := range stored.Mapping {
+		if !known.holds(field) {
+			vanished = append(vanished, string(field))
+		}
+	}
+	if len(vanished) == 0 {
+		return nil
+	}
+	slices.Sort(vanished)
+	return fmt.Errorf("the mapping names %s, which the registry no longer carries",
+		strings.Join(vanished, ", "))
+}
+
 // withinColumns reports whether the column index names a column the import carries.
 func withinColumns(column, width int) bool {
 	return column >= 0 && column < width
 }
 
 // checkAssignment reports why one assignment cannot join the mapping being built.
-func checkAssignment(one assignment, width int, assigned mapping, claimed map[fieldName]bool) error {
+func checkAssignment(
+	one assignment, width int, assigned mapping, claimed map[fieldName]bool, known registry,
+) error {
 	switch {
 	case !withinColumns(one.Column, width):
 		return fmt.Errorf("the import carries no column %d", one.Column)
-	case !mappable(one.Field):
+	case !known.holds(one.Field):
 		return fmt.Errorf("the registry carries no field %q", one.Field)
 	case assigned[strconv.Itoa(one.Column)] != "":
 		return fmt.Errorf("two assignments claim column %d", one.Column)

--- a/plugins/importer/mapping_internal_test.go
+++ b/plugins/importer/mapping_internal_test.go
@@ -7,6 +7,11 @@ import (
 	"testing"
 )
 
+// coreOnly returns the registry a plugin serving no provider answers with.
+func coreOnly() registry {
+	return registry{fields: coreFields, owner: map[fieldName]int{}}
+}
+
 func TestBuildMappingRefusesAnUnusableSet(t *testing.T) {
 	t.Parallel()
 
@@ -46,7 +51,7 @@ func TestBuildMappingRefusesAnUnusableSet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			assigned, err := buildMapping(tc.assignments, 2)
+			assigned, err := buildMapping(tc.assignments, 2, coreOnly())
 
 			if assigned != nil {
 				t.Errorf("mapping = %v, want nil for a refused set", assigned)
@@ -64,7 +69,7 @@ func TestBuildMappingKeysByColumn(t *testing.T) {
 	assigned, err := buildMapping([]assignment{
 		{Column: 1, Field: fieldEmail},
 		{Column: 0, Field: fieldContactName},
-	}, 2)
+	}, 2, coreOnly())
 
 	if err != nil {
 		t.Fatalf("buildMapping() error = %v, want nil", err)

--- a/plugins/importer/provider_test.go
+++ b/plugins/importer/provider_test.go
@@ -524,3 +524,43 @@ func TestSetMappingReportsAProviderFailure(t *testing.T) {
 		t.Errorf("error = %v, want the outage reported rather than a shrunken registry", err)
 	}
 }
+
+func TestRefusedRowReasonsCarryNoSentinelText(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(*fieldProvider){
+		"a text of another kind":     func(f *fieldProvider) { f.refuse["1990-04-17"] = "DATE" },
+		"a field no provider serves": func(f *fieldProvider) { f.fields = nil },
+		"a provider naming the field first": func(f *fieldProvider) {
+			f.checkErr = fmt.Errorf("birthDate expects DATE: %w", sdk.ErrInvalidFieldText)
+		},
+	}
+
+	for name, arrange := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := newFieldProvider(birthDate())
+			p, pool, _ := newServedPlugin(t, provider)
+			id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+			if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+				t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+			}
+			if _, err := pool.Exec(t.Context(),
+				"UPDATE plugin_importer.imports SET state = 'committing' WHERE id = $1", id); err != nil {
+				t.Fatalf("resuming the import: %v", err)
+			}
+			arrange(provider)
+
+			mustCommit(t, p, id)
+
+			reason := reasonOf(t, pool, id, 1)
+			if strings.Contains(reason, sdk.ErrInvalidFieldText.Error()) {
+				t.Errorf("reason = %q, want no sentinel text shown to an operator", reason)
+			}
+			if !strings.Contains(reason, "birthDate") {
+				t.Errorf("reason = %q, want it to name the field", reason)
+			}
+		})
+	}
+}

--- a/plugins/importer/provider_test.go
+++ b/plugins/importer/provider_test.go
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package importer_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/alphone/graph/model"
+	"github.com/gopherium/alphone/plugins/importer"
+	"github.com/gopherium/alphone/sdk"
+)
+
+var _ sdk.FieldConsumer = (*importer.Plugin)(nil)
+
+var errProvider = errors.New("the field catalogue is unreachable")
+
+// fieldProvider answers the importer with a settable set of live fields.
+type fieldProvider struct {
+	mu      sync.Mutex
+	fields  []sdk.ContactField
+	listErr error
+	refuse  map[string]string
+	written map[uuid.UUID]map[string]string
+	writes  int
+}
+
+// newFieldProvider returns a provider serving one date field.
+func newFieldProvider(fields ...sdk.ContactField) *fieldProvider {
+	return &fieldProvider{
+		fields:  fields,
+		refuse:  map[string]string{},
+		written: map[uuid.UUID]map[string]string{},
+	}
+}
+
+// LiveContactFields lists the settable fields.
+func (f *fieldProvider) LiveContactFields(context.Context) ([]sdk.ContactField, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.fields, nil
+}
+
+// CheckContactFieldTexts refuses a name the provider does not serve or a settable text.
+func (f *fieldProvider) CheckContactFieldTexts(_ context.Context, values map[string]string) error {
+	for name, text := range values {
+		if !f.holds(name) {
+			return fmt.Errorf("%w: no live field holds %s", sdk.ErrInvalidFieldText, name)
+		}
+		if kind, refused := f.refuse[text]; refused {
+			return fmt.Errorf("%w: %s expects %s", sdk.ErrInvalidFieldText, name, kind)
+		}
+	}
+	return nil
+}
+
+// WriteContactFieldTexts records the texts written onto one contact.
+func (f *fieldProvider) WriteContactFieldTexts(
+	ctx context.Context, contactID uuid.UUID, values map[string]string,
+) error {
+	if err := f.CheckContactFieldTexts(ctx, values); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes++
+	held := f.written[contactID]
+	if held == nil {
+		held = map[string]string{}
+		f.written[contactID] = held
+	}
+	for name, text := range values {
+		held[name] = text
+	}
+	return nil
+}
+
+// holds reports whether the provider serves the named field.
+func (f *fieldProvider) holds(name string) bool {
+	for _, field := range f.fields {
+		if field.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// birthDate is the field every import mapping scenario maps its third column onto.
+func birthDate() sdk.ContactField {
+	return sdk.ContactField{Name: "birthDate", Label: "Birth date"}
+}
+
+// newServedPlugin returns a committing plugin wired to the given providers.
+func newServedPlugin(t *testing.T, providers ...sdk.FieldProvider) (
+	*importer.Plugin, *pgxpool.Pool, *directory,
+) {
+	t.Helper()
+	p, pool, contacts, _ := newCommittingPlugin(t)
+	p.UseFieldProviders(providers)
+	return p, pool, contacts
+}
+
+// mapNameEmailAndField assigns the three columns of the field scenarios.
+func mapNameEmailAndField(t *testing.T, p *importer.Plugin, id uuid.UUID, field string) error {
+	t.Helper()
+	_, err := p.MutationResolvers().ImportSetMapping(t.Context(), id, []*model.ImportAssignmentInput{
+		{Column: 0, Field: "name"},
+		{Column: 1, Field: "email"},
+		{Column: 2, Field: field},
+	})
+	return err
+}
+
+// fieldCSV holds one header row and the given row beneath it.
+func fieldCSV(row string) string {
+	return "Name,Email,Birth date\n" + row + "\n"
+}
+
+// byName returns the id of the contact the directory stored under a name.
+func (d *directory) byName(t *testing.T, name string) uuid.UUID {
+	t.Helper()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for id, held := range d.contacts {
+		if held.Name == name {
+			return id
+		}
+	}
+	t.Fatalf("the directory holds no contact named %q", name)
+	return uuid.Nil
+}
+
+// stateOf returns the state one import holds.
+func stateOf(t *testing.T, pool *pgxpool.Pool, importID uuid.UUID) string {
+	t.Helper()
+	var state string
+	if err := pool.QueryRow(t.Context(),
+		"SELECT state FROM plugin_importer.imports WHERE id = $1", importID).Scan(&state); err != nil {
+		t.Fatalf("reading the import state: %v", err)
+	}
+	return state
+}
+
+// reasonOf returns the reason one staged row settled with.
+func reasonOf(t *testing.T, pool *pgxpool.Pool, importID uuid.UUID, position int) string {
+	t.Helper()
+	var reason *string
+	if err := pool.QueryRow(t.Context(),
+		"SELECT reason FROM plugin_importer.import_rows WHERE import_id = $1 AND position = $2",
+		importID, position).Scan(&reason); err != nil {
+		t.Fatalf("reading the row reason: %v", err)
+	}
+	if reason == nil {
+		return ""
+	}
+	return *reason
+}
+
+// registryNames lists the names the mappable registry answers with, in order.
+func registryNames(t *testing.T, p *importer.Plugin) []string {
+	t.Helper()
+	listed, err := p.QueryResolvers().ImportFields(t.Context())
+	if err != nil {
+		t.Fatalf("ImportFields() error = %v, want nil", err)
+	}
+	names := make([]string, len(listed))
+	for i, field := range listed {
+		names[i] = field.Name
+	}
+	return names
+}
+
+func TestImportFieldsListsProviderFieldsAfterTheCoreColumns(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := newServedPlugin(t, newFieldProvider(birthDate()))
+
+	listed, err := p.QueryResolvers().ImportFields(t.Context())
+
+	if err != nil {
+		t.Fatalf("ImportFields() error = %v, want nil", err)
+	}
+	want := []string{"name", "email", "phone", "birthDate"}
+	if len(listed) != len(want) {
+		t.Fatalf("listed = %d fields, want %d", len(listed), len(want))
+	}
+	for i, field := range listed {
+		if field.Name != want[i] {
+			t.Errorf("field %d = %q, want %q", i, field.Name, want[i])
+		}
+	}
+	if listed[3].Label != "Birth date" || listed[3].Required {
+		t.Errorf("the served field = %+v, want its label and no requirement", listed[3])
+	}
+}
+
+func TestImportFieldsServesTheCoreColumnsWithoutAProvider(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := newServedPlugin(t)
+
+	if got := registryNames(t, p); strings.Join(got, ",") != "name,email,phone" {
+		t.Errorf("names = %v, want the core columns alone", got)
+	}
+}
+
+func TestImportFieldsLeavesOutAFieldNamedAfterACoreColumn(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(sdk.ContactField{Name: "email", Label: "Second email"})
+	p, _, _ := newServedPlugin(t, provider)
+
+	names := registryNames(t, p)
+
+	var seen int
+	for _, name := range names {
+		if name == "email" {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("names = %v, want email listed exactly once", names)
+	}
+	if strings.Join(names, ",") != "name,email,phone" {
+		t.Errorf("names = %v, want the core columns alone", names)
+	}
+}
+
+func TestImportFieldsKeepsTheFirstProviderToClaimAName(t *testing.T) {
+	t.Parallel()
+
+	first := newFieldProvider(sdk.ContactField{Name: "birthDate", Label: "Birth date"})
+	second := newFieldProvider(sdk.ContactField{Name: "birthDate", Label: "Date of birth"})
+	p, _, _ := newServedPlugin(t, first, second)
+
+	listed, err := p.QueryResolvers().ImportFields(t.Context())
+
+	if err != nil {
+		t.Fatalf("ImportFields() error = %v, want nil", err)
+	}
+	if len(listed) != 4 {
+		t.Fatalf("listed = %d fields, want the name claimed once", len(listed))
+	}
+	if listed[3].Label != "Birth date" {
+		t.Errorf("label = %q, want the first provider to win", listed[3].Label)
+	}
+}
+
+func TestImportFieldsReportsAProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	provider.listErr = errProvider
+	p, _, _ := newServedPlugin(t, provider)
+
+	if _, err := p.QueryResolvers().ImportFields(t.Context()); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want the outage reported rather than a shrunken registry", err)
+	}
+}
+
+func TestSetMappingAcceptsAProviderServedField(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := newServedPlugin(t, newFieldProvider(birthDate()))
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Errorf("ImportSetMapping() error = %v, want the served field accepted", err)
+	}
+}
+
+func TestSetMappingRefusesAFieldNoProviderServes(t *testing.T) {
+	t.Parallel()
+
+	p, _, _ := newServedPlugin(t, newFieldProvider(birthDate()))
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+
+	err := mapNameEmailAndField(t, p, id, "neverDefined")
+
+	if got := refusalCode(t, err); got != "VALIDATION" {
+		t.Errorf("code = %q, want VALIDATION", got)
+	}
+}
+
+func TestCommitWritesAMappedCellIntoItsField(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, contacts := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Imported != 1 {
+		t.Fatalf("imported = %d, want 1", committed.Imported)
+	}
+	created := contacts.byName(t, "Maria Perez")
+	if provider.written[created]["birthDate"] != "1990-04-17" {
+		t.Errorf("written = %v, want the cell stored on the created contact", provider.written)
+	}
+}
+
+func TestCommitLeavesAnEmptyCellUnwritten(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Imported != 1 {
+		t.Fatalf("imported = %d, want 1", committed.Imported)
+	}
+	if provider.writes != 0 {
+		t.Errorf("writes = %d, want an empty cell to reach no provider", provider.writes)
+	}
+}
+
+func TestCommitFailsARowWhoseFieldTextIsRefused(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	provider.refuse["not a date"] = "DATE"
+	p, pool, contacts := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,not a date"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Failed != 1 || committed.Imported != 0 {
+		t.Fatalf("counts = %d failed, %d imported, want 1 and 0", committed.Failed, committed.Imported)
+	}
+	if contacts.creates != 0 {
+		t.Errorf("creates = %d, want the contact never created", contacts.creates)
+	}
+	reason := reasonOf(t, pool, id, 1)
+	for _, want := range []string{"birthDate", "DATE"} {
+		if !strings.Contains(reason, want) {
+			t.Errorf("reason = %q, want it to name %q", reason, want)
+		}
+	}
+}
+
+func TestCommitWritesNothingForASkippedRow(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, contacts := newServedPlugin(t, provider)
+	contacts.seed("Maria Perez", "maria@example.com")
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("M. Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", committed.Skipped)
+	}
+	if provider.writes != 0 {
+		t.Errorf("writes = %d, want an import to create rather than update", provider.writes)
+	}
+}
+
+func TestCommitWritesNothingWhenTheCreateLosesItsRace(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, contacts := newServedPlugin(t, provider)
+	contacts.seed("Maria Perez", "maria@example.com")
+	contacts.hideClaims = true
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("M. Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Skipped != 1 {
+		t.Fatalf("skipped = %d, want the lost race skipped", committed.Skipped)
+	}
+	if provider.writes != 0 {
+		t.Errorf("writes = %d, want nothing written onto the contact that already existed", provider.writes)
+	}
+}
+
+func TestCommitRefusesAMappingNamingAVanishedField(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, pool, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+	provider.fields = nil
+
+	_, err := commitImport(t, p, id)
+
+	if got := refusalCode(t, err); got != "VALIDATION" {
+		t.Fatalf("code = %q, want VALIDATION", got)
+	}
+	if !strings.Contains(err.Error(), "birthDate") {
+		t.Errorf("error = %v, want it to name the vanished field", err)
+	}
+	if got := stateOf(t, pool, id); got != "ready" {
+		t.Errorf("state = %q, want the import left editable", got)
+	}
+}
+
+func TestCommitReportsAProviderOutageWithoutClaiming(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, pool, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+	provider.listErr = errProvider
+
+	if _, err := commitImport(t, p, id); !errors.Is(err, errProvider) {
+		t.Fatalf("error = %v, want the outage reported", err)
+	}
+	if got := stateOf(t, pool, id); got != "ready" {
+		t.Errorf("state = %q, want the import left editable", got)
+	}
+}

--- a/plugins/importer/provider_test.go
+++ b/plugins/importer/provider_test.go
@@ -24,12 +24,14 @@ var errProvider = errors.New("the field catalogue is unreachable")
 
 // fieldProvider answers the importer with a settable set of live fields.
 type fieldProvider struct {
-	mu      sync.Mutex
-	fields  []sdk.ContactField
-	listErr error
-	refuse  map[string]string
-	written map[uuid.UUID]map[string]string
-	writes  int
+	mu       sync.Mutex
+	fields   []sdk.ContactField
+	listErr  error
+	checkErr error
+	writeErr error
+	refuse   map[string]string
+	written  map[uuid.UUID]map[string]string
+	writes   int
 }
 
 // newFieldProvider returns a provider serving one date field.
@@ -51,6 +53,9 @@ func (f *fieldProvider) LiveContactFields(context.Context) ([]sdk.ContactField, 
 
 // CheckContactFieldTexts refuses a name the provider does not serve or a settable text.
 func (f *fieldProvider) CheckContactFieldTexts(_ context.Context, values map[string]string) error {
+	if f.checkErr != nil {
+		return f.checkErr
+	}
 	for name, text := range values {
 		if !f.holds(name) {
 			return fmt.Errorf("%w: no live field holds %s", sdk.ErrInvalidFieldText, name)
@@ -66,6 +71,9 @@ func (f *fieldProvider) CheckContactFieldTexts(_ context.Context, values map[str
 func (f *fieldProvider) WriteContactFieldTexts(
 	ctx context.Context, contactID uuid.UUID, values map[string]string,
 ) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
 	if err := f.CheckContactFieldTexts(ctx, values); err != nil {
 		return err
 	}
@@ -441,5 +449,78 @@ func TestCommitReportsAProviderOutageWithoutClaiming(t *testing.T) {
 	}
 	if got := stateOf(t, pool, id); got != "ready" {
 		t.Errorf("state = %q, want the import left editable", got)
+	}
+}
+
+func TestCommitReportsAProviderCheckFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	provider.checkErr = errProvider
+	p, _, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+
+	if _, err := commitImport(t, p, id); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want an outage reported rather than a failed row", err)
+	}
+}
+
+func TestCommitReportsAProviderWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+	provider.writeErr = errProvider
+
+	if _, err := commitImport(t, p, id); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want the write failure reported", err)
+	}
+}
+
+func TestCommitFailsAResumedRowWhoseFieldVanished(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, pool, contacts := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); err != nil {
+		t.Fatalf("ImportSetMapping() error = %v, want nil", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		"UPDATE plugin_importer.imports SET state = 'committing' WHERE id = $1", id); err != nil {
+		t.Fatalf("resuming the import: %v", err)
+	}
+	provider.fields = nil
+
+	committed := mustCommit(t, p, id)
+
+	if committed.Failed != 1 {
+		t.Fatalf("failed = %d, want the resumed row refused by its own check", committed.Failed)
+	}
+	if contacts.creates != 0 {
+		t.Errorf("creates = %d, want no contact for a row naming a vanished field", contacts.creates)
+	}
+	if reason := reasonOf(t, pool, id, 1); !strings.Contains(reason, "birthDate") {
+		t.Errorf("reason = %q, want it to name the vanished field", reason)
+	}
+}
+
+func TestSetMappingReportsAProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, _ := newServedPlugin(t, provider)
+	id := uploadNamed(t, p, "leads.csv", fieldCSV("Maria Perez,maria@example.com,1990-04-17"))
+	provider.listErr = errProvider
+
+	if err := mapNameEmailAndField(t, p, id, "birthDate"); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want the outage reported rather than a shrunken registry", err)
 	}
 }

--- a/plugins/importer/seed.go
+++ b/plugins/importer/seed.go
@@ -13,10 +13,12 @@ import (
 
 // The demo import stored by [Plugin.Seed], for development only.
 const (
-	seedImportID = "0198d000-0000-7000-8000-0000000000a0"
-	seedUploader = "0198d000-0000-7000-8000-0000000000a1"
-	seedFilename = "spring-leads.csv"
-	seedClaimed  = "ada@example.com"
+	seedImportID  = "0198d000-0000-7000-8000-0000000000a0"
+	seedUploader  = "0198d000-0000-7000-8000-0000000000a1"
+	seedFilename  = "spring-leads.csv"
+	seedClaimed   = "ada@example.com"
+	seedFieldName = "birthDate"
+	seedFieldHead = "Birth date"
 )
 
 // demoRow is one scripted row of the demo import.
@@ -32,34 +34,34 @@ func demoRows() []demoRow {
 	return []demoRow{
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b1",
-			cells:   []string{"Maria Perez", "maria.perez@example.com", "184467235"},
+			cells:   []string{"Maria Perez", "maria.perez@example.com", "184467235", "1990-04-17"},
 			outcome: outcomeImported,
 		},
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b2",
-			cells:   []string{"Grace Hopper", "grace.hopper@example.com", "184467236"},
+			cells:   []string{"Grace Hopper", "grace.hopper@example.com", "184467236", "1906-12-09"},
 			outcome: outcomeImported,
 		},
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b3",
-			cells:   []string{"Alan Turing", "alan.turing@example.com", "184467237"},
+			cells:   []string{"Alan Turing", "alan.turing@example.com", "184467237", "1912-06-23"},
 			outcome: outcomeImported,
 		},
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b4",
-			cells:   []string{"Ada Lovelace", seedClaimed, ""},
+			cells:   []string{"Ada Lovelace", seedClaimed, "", "1815-12-10"},
 			outcome: outcomeSkipped,
 			reason:  "the contact detail already belongs to a contact",
 		},
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b5",
-			cells:   []string{"M. Perez", "maria.perez@example.com", ""},
+			cells:   []string{"M. Perez", "maria.perez@example.com", "", ""},
 			outcome: outcomeSkipped,
 			reason:  "the contact detail already belongs to a contact",
 		},
 		{
 			id:      "0198d000-0000-7000-8000-0000000000b6",
-			cells:   []string{"", "", "184467238"},
+			cells:   []string{"", "", "184467238", ""},
 			outcome: outcomeFailed,
 			reason:  "the row carries no name or no contact detail",
 		},
@@ -87,19 +89,40 @@ func (p *Plugin) Seed(ctx context.Context) error {
 	if exists {
 		return nil
 	}
-	rows := demoRows()
-	links, err := p.seedLinks(ctx, rows)
+	served, err := p.seedRegistry(ctx)
 	if err != nil {
 		return err
 	}
-	return p.seedImport(ctx, id, rows, links)
+	rows := demoRows()
+	links, err := p.seedLinks(ctx, rows, served)
+	if err != nil {
+		return err
+	}
+	return p.seedImport(ctx, id, rows, links, served.holds(seedFieldName))
+}
+
+// seedRegistry returns the registry the demo import fills, refusing a lost demo field.
+func (p *Plugin) seedRegistry(ctx context.Context) (registry, error) {
+	if len(p.providers) == 0 {
+		return registry{owner: map[fieldName]int{}}, nil
+	}
+	served, err := p.registry(ctx)
+	if err != nil {
+		return registry{}, err
+	}
+	if !served.holds(seedFieldName) {
+		return registry{}, fmt.Errorf("importer: the demo import expects the %q field", seedFieldName)
+	}
+	return served, nil
 }
 
 // seedLinks returns the contact each demo row points at, in position order.
-func (p *Plugin) seedLinks(ctx context.Context, rows []demoRow) ([]*uuid.UUID, error) {
+func (p *Plugin) seedLinks(
+	ctx context.Context, rows []demoRow, served registry,
+) ([]*uuid.UUID, error) {
 	links := make([]*uuid.UUID, len(rows))
 	for i, row := range rows {
-		link, err := p.seedLink(ctx, row)
+		link, err := p.seedLink(ctx, row, served)
 		if err != nil {
 			return nil, err
 		}
@@ -109,24 +132,27 @@ func (p *Plugin) seedLinks(ctx context.Context, rows []demoRow) ([]*uuid.UUID, e
 }
 
 // seedLink returns the contact one demo row points at, empty when it has none.
-func (p *Plugin) seedLink(ctx context.Context, row demoRow) (*uuid.UUID, error) {
+func (p *Plugin) seedLink(ctx context.Context, row demoRow, served registry) (*uuid.UUID, error) {
 	switch row.outcome {
 	case outcomeImported:
-		return p.seedContact(ctx, row)
+		return p.seedContact(ctx, row, served)
 	case outcomeSkipped:
 		return p.seedClaim(ctx, row)
 	}
 	return nil, nil
 }
 
-// seedContact stores the contact one imported demo row stands for.
-func (p *Plugin) seedContact(ctx context.Context, row demoRow) (*uuid.UUID, error) {
+// seedContact stores the contact one imported demo row stands for and its field value.
+func (p *Plugin) seedContact(ctx context.Context, row demoRow, served registry) (*uuid.UUID, error) {
 	created, _, err := p.contacts.CreateWithIdentities(ctx, row.cells[0], []sdk.Identity{
 		{Channel: sdk.Channel(fieldEmail), Identifier: row.cells[1]},
 		{Channel: sdk.Channel(fieldPhone), Identifier: row.cells[2]},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("importer: seed contact: %w", err)
+	}
+	if err := served.writeOne(ctx, created.ID, seedFieldName, row.cells[3]); err != nil {
+		return nil, fmt.Errorf("importer: seed field value: %w", err)
 	}
 	return &created.ID, nil
 }
@@ -145,18 +171,17 @@ func (p *Plugin) seedClaim(ctx context.Context, row demoRow) (*uuid.UUID, error)
 
 // seedImport stores the demo import and its scripted rows.
 func (p *Plugin) seedImport(
-	ctx context.Context, id uuid.UUID, rows []demoRow, links []*uuid.UUID,
+	ctx context.Context, id uuid.UUID, rows []demoRow, links []*uuid.UUID, withField bool,
 ) error {
 	counts := tally(rows)
+	headers, columns, fields := seedColumns(withField)
 	if _, err := p.pool.Exec(ctx,
 		"INSERT INTO plugin_importer.imports (id, user_id, filename, columns, mapping, "+
 			"state, row_count, imported_count, skipped_count, failed_count, created_at) "+
 			"VALUES ($1, $2, $3, $4, jsonb_object($5, $6), $7, $8, $9, $10, $11, "+
 			"now() - interval '1 day')",
 		id, uuid.MustParse(seedUploader), seedFilename,
-		[]string{"Name", "Email", "Phone"},
-		[]string{"0", "1", "2"},
-		[]string{string(fieldContactName), string(fieldEmail), string(fieldPhone)},
+		headers, columns, fields,
 		stateCommitted, len(rows),
 		counts[outcomeImported], counts[outcomeSkipped], counts[outcomeFailed],
 	); err != nil {
@@ -166,11 +191,24 @@ func (p *Plugin) seedImport(
 		if _, err := p.pool.Exec(ctx,
 			"INSERT INTO plugin_importer.import_rows (id, import_id, position, cells, "+
 				"outcome, reason, contact_id) VALUES ($1, $2, $3, to_jsonb($4::text[]), $5, $6, $7)",
-			uuid.MustParse(row.id), id, i+1, row.cells,
+			uuid.MustParse(row.id), id, i+1, row.cells[:len(headers)],
 			row.outcome, optionalReason(row.reason), links[i],
 		); err != nil {
 			return fmt.Errorf("importer: seed row %d: %w", i+1, err)
 		}
 	}
 	return nil
+}
+
+// seedColumns returns the demo header beside the mapping keys and fields it carries.
+func seedColumns(withField bool) ([]string, []string, []string) {
+	headers := []string{"Name", "Email", "Phone"}
+	columns := []string{"0", "1", "2"}
+	fields := []string{string(fieldContactName), string(fieldEmail), string(fieldPhone)}
+	if withField {
+		headers = append(headers, seedFieldHead)
+		columns = append(columns, "3")
+		fields = append(fields, seedFieldName)
+	}
+	return headers, columns, fields
 }

--- a/plugins/importer/seed_fields_test.go
+++ b/plugins/importer/seed_fields_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package importer_test
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gopherium/alphone/sdk"
+)
+
+func TestSeedFillsTheBirthDateOfEveryImportedContact(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, pool, contacts := newServedPlugin(t, provider)
+	contacts.seed("Ada Lovelace", "ada@example.com")
+
+	if err := p.Seed(t.Context()); err != nil {
+		t.Fatalf("Seed() error = %v, want nil", err)
+	}
+
+	want := map[string]string{
+		"Maria Perez":  "1990-04-17",
+		"Grace Hopper": "1906-12-09",
+		"Alan Turing":  "1912-06-23",
+	}
+	for name, day := range want {
+		id := contacts.byName(t, name)
+		if provider.written[id]["birthDate"] != day {
+			t.Errorf("%s birthDate = %q, want %q", name, provider.written[id]["birthDate"], day)
+		}
+	}
+	if len(provider.written) != len(want) {
+		t.Errorf("written = %v, want only the imported contacts filled", provider.written)
+	}
+	var columns []string
+	var fourth string
+	if err := pool.QueryRow(t.Context(),
+		"SELECT columns, mapping->>'3' FROM plugin_importer.imports").Scan(&columns, &fourth); err != nil {
+		t.Fatalf("reading the seeded mapping: %v", err)
+	}
+	if slices.Compare(columns, []string{"Name", "Email", "Phone", "Birth date"}) != 0 {
+		t.Errorf("columns = %v, want the demo header to carry the field", columns)
+	}
+	if fourth != "birthDate" {
+		t.Errorf("mapping of column 3 = %q, want birthDate", fourth)
+	}
+}
+
+func TestSeedLeavesASkippedRowsContactUntouched(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	p, _, contacts := newServedPlugin(t, provider)
+	ada := contacts.seed("Ada Lovelace", "ada@example.com")
+
+	if err := p.Seed(t.Context()); err != nil {
+		t.Fatalf("Seed() error = %v, want nil", err)
+	}
+
+	if _, written := provider.written[ada.ID]; written {
+		t.Errorf("written = %v, want the claimed contact left alone", provider.written)
+	}
+}
+
+func TestSeedRefusesWhenTheProvidersLostTheDemoField(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(sdk.ContactField{Name: "loyaltyPoints", Label: "Loyalty points"})
+	p, _, _ := newServedPlugin(t, provider)
+
+	err := p.Seed(t.Context())
+
+	if err == nil {
+		t.Fatal("Seed() error = nil, want the missing demo field refused")
+	}
+	if !strings.Contains(err.Error(), "birthDate") {
+		t.Errorf("error = %v, want it to name the field the demo import needs", err)
+	}
+}
+
+func TestSeedStoresTheCoreColumnsWithoutAProvider(t *testing.T) {
+	t.Parallel()
+
+	p, pool, contacts := newServedPlugin(t)
+	contacts.seed("Ada Lovelace", "ada@example.com")
+
+	if err := p.Seed(t.Context()); err != nil {
+		t.Fatalf("Seed() error = %v, want the demo import seeded without any provider", err)
+	}
+
+	var columns []string
+	if err := pool.QueryRow(t.Context(),
+		"SELECT columns FROM plugin_importer.imports").Scan(&columns); err != nil {
+		t.Fatalf("reading the seeded columns: %v", err)
+	}
+	if slices.Compare(columns, []string{"Name", "Email", "Phone"}) != 0 {
+		t.Errorf("columns = %v, want the core columns alone", columns)
+	}
+}
+
+func TestSeedReportsAProviderOutage(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	provider.listErr = errProvider
+	p, _, _ := newServedPlugin(t, provider)
+
+	if err := p.Seed(t.Context()); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want the outage reported", err)
+	}
+}
+
+func TestSeedReportsAFieldWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	provider := newFieldProvider(birthDate())
+	provider.writeErr = errProvider
+	p, _, _ := newServedPlugin(t, provider)
+
+	if err := p.Seed(t.Context()); !errors.Is(err, errProvider) {
+		t.Errorf("error = %v, want the failed field write reported", err)
+	}
+}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -81,8 +81,11 @@ type ContactField struct {
 
 // FieldProvider serves live contact fields and writes their values from text.
 type FieldProvider interface {
+	// LiveContactFields lists every field a column may be mapped onto.
 	LiveContactFields(ctx context.Context) ([]ContactField, error)
+	// CheckContactFieldTexts reports a text no field accepts by wrapping ErrInvalidFieldText.
 	CheckContactFieldTexts(ctx context.Context, values map[string]string) error
+	// WriteContactFieldTexts stores the values the texts describe on one contact.
 	WriteContactFieldTexts(ctx context.Context, contactID uuid.UUID, values map[string]string) error
 }
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -19,6 +19,9 @@ import (
 // ErrInvalidContact reports contact details the host refuses to store.
 var ErrInvalidContact = errors.New("sdk: invalid contact details")
 
+// ErrInvalidFieldText reports field text no live definition accepts.
+var ErrInvalidFieldText = errors.New("sdk: invalid field text")
+
 // Plugin is an independently addable unit of functionality with a
 // managed lifecycle.
 type Plugin = pluginkit.Plugin
@@ -66,6 +69,26 @@ type GraphField struct {
 // FieldSource reports the runtime defined fields a plugin serves.
 type FieldSource interface {
 	FieldsSnapshot(ctx context.Context) (uint64, []GraphField, error)
+}
+
+// ContactField is one live field a column may be mapped onto.
+type ContactField struct {
+	// Name is the field name a mapping stores.
+	Name string
+	// Label is the text an operator reads on screen.
+	Label string
+}
+
+// FieldProvider serves live contact fields and writes their values from text.
+type FieldProvider interface {
+	LiveContactFields(ctx context.Context) ([]ContactField, error)
+	CheckContactFieldTexts(ctx context.Context, values map[string]string) error
+	WriteContactFieldTexts(ctx context.Context, contactID uuid.UUID, values map[string]string) error
+}
+
+// FieldConsumer receives the registered field providers.
+type FieldConsumer interface {
+	UseFieldProviders(providers []FieldProvider)
 }
 
 // Channel names a communication medium, such as "whatsapp" or "email".

--- a/test/e2e/tests/importer.spec.ts
+++ b/test/e2e/tests/importer.spec.ts
@@ -75,3 +75,46 @@ test('imports a CSV of contacts from the upload through to the contact list', as
 	await expect(page.getByRole('link', { name: wanted })).toBeVisible()
 	await expect(page.getByRole('link', { name: known })).toHaveCount(1)
 })
+
+test('maps a spreadsheet column onto a field an operator defined', async ({ page }) => {
+	const stamp = Date.now()
+	const wanted = `Maria Perez ${stamp}`
+	const field = `joinedOn${stamp}`
+	const fieldLabel = `Joined on ${stamp}`
+
+	await page.goto('/')
+	await page.getByRole('link', { name: 'Fields' }).click()
+	await expect(page.getByRole('heading', { name: 'Fields', level: 1 })).toBeVisible()
+	await page.getByLabel('Label').fill(fieldLabel)
+	await page.getByLabel('Name').fill(field)
+	await page.getByRole('combobox', { name: 'Kind' }).click()
+	await page.getByRole('listbox').getByRole('option', { name: 'Date', exact: true }).click()
+	await page.getByRole('button', { name: 'Add field' }).click()
+	await expect(page.getByRole('region', { name: 'Fields' }).getByText(field)).toBeVisible()
+
+	await page.getByRole('link', { name: 'Import' }).click()
+	await page.getByLabel('Contacts file').setInputFiles({
+		name: 'joined.csv',
+		mimeType: 'text/csv',
+		buffer: Buffer.from(
+			'Full name,Email address,Joined\n' + `${wanted},maria.${stamp}@example.com,2026-03-01\n`,
+		),
+	})
+	await page.getByRole('link', { name: 'joined.csv' }).click()
+	await expect(page.getByRole('heading', { name: 'joined.csv' })).toBeVisible()
+
+	await chooseField(page, 'Full name', 'Name')
+	await chooseField(page, 'Email address', 'Email')
+	await chooseField(page, 'Joined', fieldLabel)
+	await page.getByRole('button', { name: 'Save mapping' }).click()
+	await page.getByRole('button', { name: 'Commit' }).click()
+	await expect(
+		page.getByRole('region', { name: 'Rows' }).getByText('imported', { exact: true }).first(),
+	).toBeVisible()
+
+	await page.getByRole('link', { name: 'Contacts' }).click()
+	await page.getByRole('textbox', { name: 'Search contacts' }).fill(String(stamp))
+	await page.getByRole('link', { name: wanted }).click()
+	await expect(page.getByRole('heading', { name: wanted })).toBeVisible()
+	await expect(page.getByLabel(fieldLabel)).toHaveValue('2026-03-01')
+})

--- a/test/features/features/import-fields.feature
+++ b/test/features/features/import-fields.feature
@@ -47,7 +47,7 @@ Feature: A spreadsheet fills the fields
 
   Scenario: A field named after a core column stays out of the registry
     When the operator defines the field "email" labelled "Second email" of kind TEXT
-    Then the mapping registry lists "email" exactly once
+    Then the mapping registry lists "email" exactly once, labelled "Email"
 
   Scenario: A skipped row leaves the existing contact's fields untouched
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined

--- a/test/features/features/import-fields.feature
+++ b/test/features/features/import-fields.feature
@@ -7,12 +7,10 @@ Feature: A spreadsheet fills the fields
   Background:
     Given a running AlphOne holding a user with an API token
 
-  @wip
   Scenario: A live field joins the mapping registry beside the core columns
     When the operator defines the field "birthDate" labelled "Birth date" of kind DATE
     Then the mapping registry lists "birthDate" labelled "Birth date" beside the core columns
 
-  @wip
   Scenario: A committed import writes a mapped cell into its field
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined
     And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,1990-04-17"
@@ -21,7 +19,6 @@ Feature: A spreadsheet fills the fields
     Then the commit answers 1 imported
     And the contact "Maria Perez" answers "1990-04-17" for the field "birthDate"
 
-  @wip
   Scenario: An empty cell writes nothing
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined
     And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,"
@@ -30,7 +27,6 @@ Feature: A spreadsheet fills the fields
     Then the commit answers 1 imported
     And the contact "Maria Perez" answers null for the field "birthDate"
 
-  @wip
   Scenario: A cell that does not fit its kind fails the row and creates no contact
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined
     And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,not a date"
@@ -40,7 +36,6 @@ Feature: A spreadsheet fills the fields
     And a row settles failed naming "birthDate" and kind DATE
     And no contact named "Maria Perez" exists
 
-  @wip
   Scenario: Archiving a mapped field refuses the commit and keeps the import ready
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined
     And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,1990-04-17"
@@ -50,12 +45,10 @@ Feature: A spreadsheet fills the fields
     Then the commit is refused naming "birthDate"
     And the import stays ready for a new mapping
 
-  @wip
   Scenario: A field named after a core column stays out of the registry
     When the operator defines the field "email" labelled "Second email" of kind TEXT
     Then the mapping registry lists "email" exactly once
 
-  @wip
   Scenario: A skipped row leaves the existing contact's fields untouched
     Given the field "birthDate" labelled "Birth date" of kind DATE is defined
     And a contact named "Maria Perez" reachable at "maria@example.com"

--- a/test/features/features/import-fields.feature
+++ b/test/features/features/import-fields.feature
@@ -1,0 +1,66 @@
+Feature: A spreadsheet fills the fields
+  A CSV column maps onto a runtime field the same way it maps onto name,
+  email and phone. Values are checked before a contact is created, an
+  import only ever creates, and a mapping naming a vanished field refuses
+  the commit while the import is still editable.
+
+  Background:
+    Given a running AlphOne holding a user with an API token
+
+  @wip
+  Scenario: A live field joins the mapping registry beside the core columns
+    When the operator defines the field "birthDate" labelled "Birth date" of kind DATE
+    Then the mapping registry lists "birthDate" labelled "Birth date" beside the core columns
+
+  @wip
+  Scenario: A committed import writes a mapped cell into its field
+    Given the field "birthDate" labelled "Birth date" of kind DATE is defined
+    And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,1990-04-17"
+    And the columns are mapped onto name, email and the field "birthDate"
+    When the import is committed
+    Then the commit answers 1 imported
+    And the contact "Maria Perez" answers "1990-04-17" for the field "birthDate"
+
+  @wip
+  Scenario: An empty cell writes nothing
+    Given the field "birthDate" labelled "Birth date" of kind DATE is defined
+    And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,"
+    And the columns are mapped onto name, email and the field "birthDate"
+    When the import is committed
+    Then the commit answers 1 imported
+    And the contact "Maria Perez" answers null for the field "birthDate"
+
+  @wip
+  Scenario: A cell that does not fit its kind fails the row and creates no contact
+    Given the field "birthDate" labelled "Birth date" of kind DATE is defined
+    And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,not a date"
+    And the columns are mapped onto name, email and the field "birthDate"
+    When the import is committed
+    Then the commit answers 1 failed
+    And a row settles failed naming "birthDate" and kind DATE
+    And no contact named "Maria Perez" exists
+
+  @wip
+  Scenario: Archiving a mapped field refuses the commit and keeps the import ready
+    Given the field "birthDate" labelled "Birth date" of kind DATE is defined
+    And an uploaded spreadsheet holding the row "Maria Perez,maria@example.com,1990-04-17"
+    And the columns are mapped onto name, email and the field "birthDate"
+    When the operator archives the field "birthDate"
+    And the import is committed
+    Then the commit is refused naming "birthDate"
+    And the import stays ready for a new mapping
+
+  @wip
+  Scenario: A field named after a core column stays out of the registry
+    When the operator defines the field "email" labelled "Second email" of kind TEXT
+    Then the mapping registry lists "email" exactly once
+
+  @wip
+  Scenario: A skipped row leaves the existing contact's fields untouched
+    Given the field "birthDate" labelled "Birth date" of kind DATE is defined
+    And a contact named "Maria Perez" reachable at "maria@example.com"
+    And an uploaded spreadsheet holding the row "M. Perez,maria@example.com,1990-04-17"
+    And the columns are mapped onto name, email and the field "birthDate"
+    When the import is committed
+    Then the commit answers 1 skipped
+    And the contact "Maria Perez" answers null for the field "birthDate"

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -73,6 +73,11 @@ func initializeFieldsGraph(t *testing.T) func(*godog.ScenarioContext) {
 	return func(sc *godog.ScenarioContext) { registerFieldsGraphSteps(sc, t) }
 }
 
+// initializeImportFields registers the import mapping steps.
+func initializeImportFields(t *testing.T) func(*godog.ScenarioContext) {
+	return func(sc *godog.ScenarioContext) { registerImportFieldsSteps(sc, t) }
+}
+
 func TestMCPSession(t *testing.T) {
 	runFeature(t, "features/mcp-session.feature", initializeSession(t))
 }
@@ -99,4 +104,8 @@ func TestFieldsValues(t *testing.T) {
 
 func TestFieldsGraph(t *testing.T) {
 	runFeature(t, "features/fields-graph.feature", initializeFieldsGraph(t))
+}
+
+func TestImportFields(t *testing.T) {
+	runFeature(t, "features/import-fields.feature", initializeImportFields(t))
 }

--- a/test/features/steps_fields_test.go
+++ b/test/features/steps_fields_test.go
@@ -100,7 +100,11 @@ func registerFieldsCatalogSteps(sc *godog.ScenarioContext, t *testing.T) {
 	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
 		return context.WithValue(ctx, worldKey{}, newWorld(t)), nil
 	})
+	bindFieldsCatalogSteps(sc)
+}
 
+// bindFieldsCatalogSteps binds the catalogue steps onto an already booted world.
+func bindFieldsCatalogSteps(sc *godog.ScenarioContext) {
 	sc.Given(`^a running AlphOne holding a user with an API token$`, func(ctx context.Context) error {
 		if worldFrom(ctx).secret == "" {
 			return fmt.Errorf("the scenario holds no token")

--- a/test/features/steps_import_fields_test.go
+++ b/test/features/steps_import_fields_test.go
@@ -308,21 +308,26 @@ func registerImportFieldsSteps(sc *godog.ScenarioContext, t *testing.T) {
 			return nil
 		})
 
-	sc.Then(`^the mapping registry lists "([^"]*)" exactly once$`,
-		func(ctx context.Context, name string) error {
+	sc.Then(`^the mapping registry lists "([^"]*)" exactly once, labelled "([^"]*)"$`,
+		func(ctx context.Context, name, label string) error {
 			w := worldFrom(ctx)
 			answer, err := w.importOperation(ctx, registryQuery, nil)
 			if err != nil {
 				return err
 			}
 			var seen int
+			var found string
 			for _, field := range answer.Data.ImportFields {
 				if field.Name == name {
 					seen++
+					found = field.Label
 				}
 			}
 			if seen != 1 {
 				return fmt.Errorf("the registry lists %q %d times, want once", name, seen)
+			}
+			if found != label {
+				return fmt.Errorf("%s is labelled %q, want the core column's %q", name, found, label)
 			}
 			return nil
 		})

--- a/test/features/steps_import_fields_test.go
+++ b/test/features/steps_import_fields_test.go
@@ -178,7 +178,10 @@ func (w *world) readContactField(ctx context.Context, contactName, field string)
 
 // registerImportFieldsSteps binds the import mapping steps and the world lifecycle.
 func registerImportFieldsSteps(sc *godog.ScenarioContext, t *testing.T) {
-	registerFieldsCatalogSteps(sc, t)
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		return context.WithValue(ctx, worldKey{}, newImportWorld(t)), nil
+	})
+	bindFieldsCatalogSteps(sc)
 
 	sc.Given(`^a contact named "([^"]*)" reachable at "([^"]*)"$`,
 		func(ctx context.Context, name, email string) error {

--- a/test/features/steps_import_fields_test.go
+++ b/test/features/steps_import_fields_test.go
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package features_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+	"github.com/google/uuid"
+)
+
+// importHeader is the header row every import scenario uploads.
+const importHeader = "Name,Email,Birth date"
+
+// uploadOperation is the multipart operations payload declaring the upload.
+const uploadOperation = `{"query":"mutation($file: Upload!) { importUpload(file: $file) { id state columns } }",` +
+	`"variables":{"file":null}}`
+
+// setMappingMutation assigns the uploaded columns to fields.
+const setMappingMutation = `mutation($id: UUID!, $assignments: [ImportAssignmentInput!]!) {
+	importSetMapping(id: $id, assignments: $assignments) { id state }
+}`
+
+// commitMutation turns the staged rows into contacts.
+const commitMutation = `mutation($id: UUID!) {
+	importCommit(id: $id) { imported skipped failed }
+}`
+
+// importJobQuery reads one import's state and rows back.
+const importJobQuery = `query($id: UUID!) {
+	importJob(id: $id) { state rows { outcome reason } }
+}`
+
+// registryQuery reads the mappable registry.
+const registryQuery = `{ importFields { name label required } }`
+
+// contactsFieldQuery lists contacts with one runtime defined field selected.
+const contactsFieldQuery = `{ contacts(first: 50) { edges { node { name %s } } } }`
+
+// importAnswer is the envelope every import step reads.
+type importAnswer struct {
+	Data struct {
+		ImportUpload struct {
+			ID      string   `json:"id"`
+			State   string   `json:"state"`
+			Columns []string `json:"columns"`
+		} `json:"importUpload"`
+		ImportCommit struct {
+			Imported int `json:"imported"`
+			Skipped  int `json:"skipped"`
+			Failed   int `json:"failed"`
+		} `json:"importCommit"`
+		ImportJob *struct {
+			State string `json:"state"`
+			Rows  []struct {
+				Outcome string  `json:"outcome"`
+				Reason  *string `json:"reason"`
+			} `json:"rows"`
+		} `json:"importJob"`
+		ImportFields []struct {
+			Name     string `json:"name"`
+			Label    string `json:"label"`
+			Required bool   `json:"required"`
+		} `json:"importFields"`
+		Contacts *struct {
+			Edges []struct {
+				Node map[string]any `json:"node"`
+			} `json:"edges"`
+		} `json:"contacts"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// importOperation posts a graph operation and decodes the import envelope.
+func (w *world) importOperation(ctx context.Context, document string, variables map[string]any) (importAnswer, error) {
+	payload := map[string]any{"query": document}
+	if variables != nil {
+		payload["variables"] = variables
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return importAnswer{}, fmt.Errorf("encoding the operation: %w", err)
+	}
+	raw, err := w.postGraph(ctx, string(body))
+	if err != nil {
+		return importAnswer{}, err
+	}
+	w.answered = raw
+	var answer importAnswer
+	if err := json.Unmarshal(raw, &answer); err != nil {
+		return importAnswer{}, fmt.Errorf("decoding %s: %w", raw, err)
+	}
+	return answer, nil
+}
+
+// uploadSpreadsheet posts a one row CSV through the multipart upload protocol.
+func (w *world) uploadSpreadsheet(ctx context.Context, row string) error {
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	if err := form.WriteField("operations", uploadOperation); err != nil {
+		return fmt.Errorf("writing the operations part: %w", err)
+	}
+	if err := form.WriteField("map", `{"0":["variables.file"]}`); err != nil {
+		return fmt.Errorf("writing the map part: %w", err)
+	}
+	part, err := form.CreateFormFile("0", "spring-leads.csv")
+	if err != nil {
+		return fmt.Errorf("creating the file part: %w", err)
+	}
+	if _, err := part.Write([]byte(importHeader + "\n" + row + "\n")); err != nil {
+		return fmt.Errorf("writing the file part: %w", err)
+	}
+	if err := form.Close(); err != nil {
+		return fmt.Errorf("closing the form: %w", err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, w.server.URL+"/api/graphql", &body)
+	if err != nil {
+		return fmt.Errorf("building the upload request: %w", err)
+	}
+	request.Header.Set("Content-Type", form.FormDataContentType())
+	request.Header.Set("Authorization", "Bearer "+w.secret)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("posting the upload: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	raw, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("reading the upload answer: %w", err)
+	}
+	w.answered = raw
+	var answer importAnswer
+	if err := json.Unmarshal(raw, &answer); err != nil {
+		return fmt.Errorf("decoding %s: %w", raw, err)
+	}
+	if len(answer.Errors) > 0 {
+		return fmt.Errorf("the upload was refused, answered %s", raw)
+	}
+	parsed, err := uuid.Parse(answer.Data.ImportUpload.ID)
+	if err != nil {
+		return fmt.Errorf("reading the import id from %s: %w", raw, err)
+	}
+	w.lastImport = parsed
+	return nil
+}
+
+// readContactField finds one contact by name in a listing selecting the field.
+func (w *world) readContactField(ctx context.Context, contactName, field string) (any, bool, error) {
+	listing := fmt.Sprintf(contactsFieldQuery, field)
+	answer, err := w.importOperation(ctx, listing, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(answer.Errors) > 0 {
+		return nil, false, fmt.Errorf("the listing was refused, answered %s", w.answered)
+	}
+	if answer.Data.Contacts == nil {
+		return nil, false, fmt.Errorf("the listing answered no contacts, answered %s", w.answered)
+	}
+	for _, edge := range answer.Data.Contacts.Edges {
+		if edge.Node["name"] == contactName {
+			return edge.Node[field], true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// registerImportFieldsSteps binds the import mapping steps and the world lifecycle.
+func registerImportFieldsSteps(sc *godog.ScenarioContext, t *testing.T) {
+	registerFieldsCatalogSteps(sc, t)
+
+	sc.Given(`^a contact named "([^"]*)" reachable at "([^"]*)"$`,
+		func(ctx context.Context, name, email string) error {
+			return worldFrom(ctx).seedReachableContact(ctx, name, email)
+		})
+
+	sc.Given(`^an uploaded spreadsheet holding the row "([^"]*)"$`,
+		func(ctx context.Context, row string) error {
+			return worldFrom(ctx).uploadSpreadsheet(ctx, row)
+		})
+
+	sc.Given(`^the columns are mapped onto name, email and the field "([^"]*)"$`,
+		func(ctx context.Context, field string) error {
+			w := worldFrom(ctx)
+			answer, err := w.importOperation(ctx, setMappingMutation, map[string]any{
+				"id": w.lastImport.String(),
+				"assignments": []map[string]any{
+					{"column": 0, "field": "name"},
+					{"column": 1, "field": "email"},
+					{"column": 2, "field": field},
+				},
+			})
+			if err != nil {
+				return err
+			}
+			if len(answer.Errors) > 0 {
+				return fmt.Errorf("the mapping was refused, answered %s", w.answered)
+			}
+			return nil
+		})
+
+	sc.When(`^the import is committed$`, func(ctx context.Context) error {
+		w := worldFrom(ctx)
+		_, err := w.importOperation(ctx, commitMutation, map[string]any{"id": w.lastImport.String()})
+		return err
+	})
+
+	sc.Then(`^the commit answers (\d+) (imported|skipped|failed)$`,
+		func(ctx context.Context, want int, outcome string) error {
+			w := worldFrom(ctx)
+			var answer importAnswer
+			if err := json.Unmarshal(w.answered, &answer); err != nil {
+				return fmt.Errorf("decoding %s: %w", w.answered, err)
+			}
+			if len(answer.Errors) > 0 {
+				return fmt.Errorf("the commit was refused, answered %s", w.answered)
+			}
+			counts := map[string]int{
+				"imported": answer.Data.ImportCommit.Imported,
+				"skipped":  answer.Data.ImportCommit.Skipped,
+				"failed":   answer.Data.ImportCommit.Failed,
+			}
+			if counts[outcome] != want {
+				return fmt.Errorf("%s = %d, want %d, answered %s", outcome, counts[outcome], want, w.answered)
+			}
+			return nil
+		})
+
+	sc.Then(`^the commit is refused naming "([^"]*)"$`, func(ctx context.Context, name string) error {
+		w := worldFrom(ctx)
+		if err := w.refusedFor("VALIDATION"); err != nil {
+			return err
+		}
+		if !strings.Contains(string(w.answered), name) {
+			return fmt.Errorf("the refusal does not name %q, answered %s", name, w.answered)
+		}
+		return nil
+	})
+
+	sc.Then(`^the import stays ready for a new mapping$`, func(ctx context.Context) error {
+		w := worldFrom(ctx)
+		answer, err := w.importOperation(ctx, importJobQuery, map[string]any{"id": w.lastImport.String()})
+		if err != nil {
+			return err
+		}
+		if answer.Data.ImportJob == nil {
+			return fmt.Errorf("the import is gone, answered %s", w.answered)
+		}
+		if answer.Data.ImportJob.State != "ready" {
+			return fmt.Errorf("state = %q, want ready", answer.Data.ImportJob.State)
+		}
+		return nil
+	})
+
+	sc.Then(`^a row settles failed naming "([^"]*)" and kind ([A-Z]+)$`,
+		func(ctx context.Context, field, kind string) error {
+			w := worldFrom(ctx)
+			answer, err := w.importOperation(ctx, importJobQuery, map[string]any{"id": w.lastImport.String()})
+			if err != nil {
+				return err
+			}
+			if answer.Data.ImportJob == nil {
+				return fmt.Errorf("the import is gone, answered %s", w.answered)
+			}
+			for _, row := range answer.Data.ImportJob.Rows {
+				if row.Outcome != "failed" || row.Reason == nil {
+					continue
+				}
+				if strings.Contains(*row.Reason, field) && strings.Contains(*row.Reason, kind) {
+					return nil
+				}
+			}
+			return fmt.Errorf("no failed row names %q and %s, answered %s", field, kind, w.answered)
+		})
+
+	sc.Then(`^the mapping registry lists "([^"]*)" labelled "([^"]*)" beside the core columns$`,
+		func(ctx context.Context, name, label string) error {
+			listed, err := worldFrom(ctx).readRegistry(ctx)
+			if err != nil {
+				return err
+			}
+			for _, core := range []string{"name", "email", "phone"} {
+				if !listed[core] {
+					return fmt.Errorf("the registry lost the core column %q", core)
+				}
+			}
+			w := worldFrom(ctx)
+			if !listed[name] {
+				return fmt.Errorf("the registry does not list %q, answered %s", name, w.answered)
+			}
+			if !strings.Contains(string(w.answered), label) {
+				return fmt.Errorf("the registry does not carry the label %q, answered %s", label, w.answered)
+			}
+			return nil
+		})
+
+	sc.Then(`^the mapping registry lists "([^"]*)" exactly once$`,
+		func(ctx context.Context, name string) error {
+			w := worldFrom(ctx)
+			answer, err := w.importOperation(ctx, registryQuery, nil)
+			if err != nil {
+				return err
+			}
+			var seen int
+			for _, field := range answer.Data.ImportFields {
+				if field.Name == name {
+					seen++
+				}
+			}
+			if seen != 1 {
+				return fmt.Errorf("the registry lists %q %d times, want once", name, seen)
+			}
+			return nil
+		})
+
+	sc.Then(`^the contact "([^"]*)" answers "([^"]*)" for the field "([^"]*)"$`,
+		func(ctx context.Context, contactName, want, field string) error {
+			got, found, err := worldFrom(ctx).readContactField(ctx, contactName, field)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("no contact named %q was listed", contactName)
+			}
+			if got != want {
+				return fmt.Errorf("%s = %#v, want %q", field, got, want)
+			}
+			return nil
+		})
+
+	sc.Then(`^the contact "([^"]*)" answers null for the field "([^"]*)"$`,
+		func(ctx context.Context, contactName, field string) error {
+			got, found, err := worldFrom(ctx).readContactField(ctx, contactName, field)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("no contact named %q was listed", contactName)
+			}
+			if got != nil {
+				return fmt.Errorf("%s = %#v, want null", field, got)
+			}
+			return nil
+		})
+
+	sc.Then(`^no contact named "([^"]*)" exists$`, func(ctx context.Context, contactName string) error {
+		_, found, err := worldFrom(ctx).readContactField(ctx, contactName, "name")
+		if err != nil {
+			return err
+		}
+		if found {
+			return fmt.Errorf("a contact named %q exists", contactName)
+		}
+		return nil
+	})
+}
+
+// readRegistry reads the mappable registry into a set of names.
+func (w *world) readRegistry(ctx context.Context) (map[string]bool, error) {
+	answer, err := w.importOperation(ctx, registryQuery, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(answer.Errors) > 0 {
+		return nil, fmt.Errorf("the registry was refused, answered %s", w.answered)
+	}
+	listed := make(map[string]bool, len(answer.Data.ImportFields))
+	for _, field := range answer.Data.ImportFields {
+		listed[field.Name] = true
+	}
+	return listed, nil
+}

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -91,6 +91,7 @@ func newWorld(t *testing.T) *world {
 	resolver := contact.NewResolver(contacts)
 	fieldsPlugin := livePlugin(t, cfg.URL())
 	importerPlugin := liveImporter(t, cfg.URL(), scenarioDirectory{resolver: resolver})
+	importerPlugin.UseFieldProviders([]sdk.FieldProvider{fieldsPlugin})
 	registered := append(inertPlugins(t), importerPlugin, fieldsPlugin)
 	root, err := graphroot.FromPlugins(&graphres.Resolver{
 		Version:      "test",

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -70,11 +71,23 @@ type world struct {
 // newWorld boots an isolated database and a real server for one scenario.
 func newWorld(t *testing.T) *world {
 	t.Helper()
+	return bootWorld(t, false)
+}
+
+// newImportWorld boots a scenario whose importer runs against the real database.
+func newImportWorld(t *testing.T) *world {
+	t.Helper()
+	return bootWorld(t, true)
+}
+
+// bootWorld boots one scenario, running the importer live only when asked.
+func bootWorld(t *testing.T, liveImports bool) *world {
+	t.Helper()
 	cfg := pgtestdb.Custom(t, testdb.Config(), testdb.CoreMigrator())
 	if err := authkitpg.Migrate(context.Background(), cfg.URL()); err != nil {
 		t.Fatalf("migrating the auth schema: %v", err)
 	}
-	pool, err := pgxpool.New(context.Background(), cfg.URL())
+	pool, err := pgxpool.New(context.Background(), sparingly(cfg.URL()))
 	if err != nil {
 		t.Fatalf("connecting the scenario pool: %v", err)
 	}
@@ -90,9 +103,12 @@ func newWorld(t *testing.T) *world {
 
 	resolver := contact.NewResolver(contacts)
 	fieldsPlugin := livePlugin(t, cfg.URL())
-	importerPlugin := liveImporter(t, cfg.URL(), scenarioDirectory{resolver: resolver})
-	importerPlugin.UseFieldProviders([]sdk.FieldProvider{fieldsPlugin})
-	registered := append(inertPlugins(t), importerPlugin, fieldsPlugin)
+	registered := append(inertPlugins(t, liveImports), fieldsPlugin)
+	if liveImports {
+		importerPlugin := liveImporter(t, cfg.URL(), scenarioDirectory{resolver: resolver})
+		importerPlugin.UseFieldProviders([]sdk.FieldProvider{fieldsPlugin})
+		registered = append(registered, importerPlugin)
+	}
 	root, err := graphroot.FromPlugins(&graphres.Resolver{
 		Version:      "test",
 		Contacts:     contacts,
@@ -145,10 +161,19 @@ func newWorld(t *testing.T) *world {
 	}
 }
 
+// sparingly returns the database URL with a pool small enough for a whole suite.
+func sparingly(databaseURL string) string {
+	separator := "?"
+	if strings.Contains(databaseURL, "?") {
+		separator = "&"
+	}
+	return databaseURL + separator + "pool_max_conns=2"
+}
+
 // livePlugin registers the fields plugin against the scenario's own database.
 func livePlugin(t *testing.T, databaseURL string) *fields.Plugin {
 	t.Helper()
-	plugin, err := fields.Register(sdk.Deps{DatabaseURL: databaseURL})
+	plugin, err := fields.Register(sdk.Deps{DatabaseURL: sparingly(databaseURL)})
 	if err != nil {
 		t.Fatalf("registering fields: %v", err)
 	}
@@ -165,7 +190,9 @@ func livePlugin(t *testing.T, databaseURL string) *fields.Plugin {
 // liveImporter registers the importer plugin against the scenario's own database.
 func liveImporter(t *testing.T, databaseURL string, directory sdk.ContactDirectory) *importer.Plugin {
 	t.Helper()
-	plugin, err := importer.Register(sdk.Deps{DatabaseURL: databaseURL, Contacts: directory})
+	plugin, err := importer.Register(sdk.Deps{
+		DatabaseURL: sparingly(databaseURL), Contacts: directory,
+	})
 	if err != nil {
 		t.Fatalf("registering importer: %v", err)
 	}
@@ -238,7 +265,7 @@ func worldFrom(ctx context.Context) *world {
 }
 
 // inertPlugins registers every graph contributing plugin against a lazy pool.
-func inertPlugins(t *testing.T) []sdk.Plugin {
+func inertPlugins(t *testing.T, liveImports bool) []sdk.Plugin {
 	t.Helper()
 	const unreachable = "postgres://plugin:plugin@localhost:1/plugin"
 	whatsappPlugin, err := whatsapp.Register(sdk.Deps{DatabaseURL: unreachable})
@@ -246,7 +273,16 @@ func inertPlugins(t *testing.T) []sdk.Plugin {
 		t.Fatalf("registering whatsapp: %v", err)
 	}
 	t.Cleanup(func() { _ = whatsappPlugin.Stop(context.Background()) })
-	return []sdk.Plugin{whatsappPlugin}
+	registered := []sdk.Plugin{whatsappPlugin}
+	if liveImports {
+		return registered
+	}
+	importerPlugin, err := importer.Register(sdk.Deps{DatabaseURL: unreachable})
+	if err != nil {
+		t.Fatalf("registering importer: %v", err)
+	}
+	t.Cleanup(func() { _ = importerPlugin.Stop(context.Background()) })
+	return append(registered, importerPlugin)
 }
 
 // addUser stores another user and returns its id.

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -4,6 +4,7 @@ package features_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -50,7 +51,9 @@ type world struct {
 	pool        *pgxpool.Pool
 	tasks       *postgres.TaskStore
 	contacts    *postgres.ContactStore
+	resolver    *contact.Resolver
 	lastContact uuid.UUID
+	lastImport  uuid.UUID
 	users       *authkitpg.UserStore
 	server      *httptest.Server
 	ownerID     uuid.UUID
@@ -85,8 +88,10 @@ func newWorld(t *testing.T) *world {
 	hub := event.NewHub()
 	auth := authkit.New(authkit.Config{Store: users, CookieName: server.SessionCookieName})
 
+	resolver := contact.NewResolver(contacts)
 	fieldsPlugin := livePlugin(t, cfg.URL())
-	registered := append(inertPlugins(t), fieldsPlugin)
+	importerPlugin := liveImporter(t, cfg.URL(), scenarioDirectory{resolver: resolver})
+	registered := append(inertPlugins(t), importerPlugin, fieldsPlugin)
 	root, err := graphroot.FromPlugins(&graphres.Resolver{
 		Version:      "test",
 		Contacts:     contacts,
@@ -130,6 +135,7 @@ func newWorld(t *testing.T) *world {
 		pool:     pool,
 		tasks:    tasks,
 		contacts: contacts,
+		resolver: resolver,
 		users:    users,
 		server:   srv,
 		ownerID:  owner.ID,
@@ -155,6 +161,76 @@ func livePlugin(t *testing.T, databaseURL string) *fields.Plugin {
 	return plugin
 }
 
+// liveImporter registers the importer plugin against the scenario's own database.
+func liveImporter(t *testing.T, databaseURL string, directory sdk.ContactDirectory) *importer.Plugin {
+	t.Helper()
+	plugin, err := importer.Register(sdk.Deps{DatabaseURL: databaseURL, Contacts: directory})
+	if err != nil {
+		t.Fatalf("registering importer: %v", err)
+	}
+	t.Cleanup(func() { _ = plugin.Stop(context.Background()) })
+	if err := plugin.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrating importer: %v", err)
+	}
+	if err := plugin.Start(context.Background()); err != nil {
+		t.Fatalf("starting importer: %v", err)
+	}
+	return plugin
+}
+
+// invalidContactErrors lists the domain errors a plugin reads as unusable details.
+var invalidContactErrors = []error{
+	contact.ErrEmptyName,
+	contact.ErrEmptyChannel,
+	contact.ErrEmptyIdentifier,
+	contact.ErrChannelNotWritable,
+}
+
+// markInvalid returns err with unusable contact details marked for the plugin.
+func markInvalid(err error) error {
+	for _, invalid := range invalidContactErrors {
+		if errors.Is(err, invalid) {
+			return fmt.Errorf("%w: %w", sdk.ErrInvalidContact, err)
+		}
+	}
+	return err
+}
+
+// scenarioDirectory bridges the scenario's contact resolver to the plugin contract.
+type scenarioDirectory struct {
+	resolver *contact.Resolver
+}
+
+// FindByIdentity returns the [sdk.Contact] owning an identity, reporting whether one exists.
+func (d scenarioDirectory) FindByIdentity(
+	ctx context.Context, channel sdk.Channel, identifier string,
+) (sdk.Contact, bool, error) {
+	owner, found, err := d.resolver.FindByIdentity(ctx, contact.Channel(channel), identifier)
+	if err != nil || !found {
+		return sdk.Contact{}, false, markInvalid(err)
+	}
+	return sdk.Contact{ID: owner.ID, Name: owner.Name}, true, nil
+}
+
+// CreateWithIdentities stores an [sdk.Contact] owning every identity, reporting whether it was created.
+func (d scenarioDirectory) CreateWithIdentities(
+	ctx context.Context, name string, identities []sdk.Identity,
+) (sdk.Contact, bool, error) {
+	addresses := make([]contact.Address, 0, len(identities))
+	for _, identity := range identities {
+		addresses = append(addresses, contact.Address{
+			Channel:     contact.Channel(identity.Channel),
+			Identifier:  identity.Identifier,
+			DisplayName: identity.DisplayName,
+		})
+	}
+	owner, created, err := d.resolver.CreateWithIdentities(ctx, name, addresses)
+	if err != nil {
+		return sdk.Contact{}, false, markInvalid(err)
+	}
+	return sdk.Contact{ID: owner.ID, Name: owner.Name}, created, nil
+}
+
 // worldFrom returns the world the scenario carries.
 func worldFrom(ctx context.Context) *world {
 	return ctx.Value(worldKey{}).(*world)
@@ -169,12 +245,7 @@ func inertPlugins(t *testing.T) []sdk.Plugin {
 		t.Fatalf("registering whatsapp: %v", err)
 	}
 	t.Cleanup(func() { _ = whatsappPlugin.Stop(context.Background()) })
-	importerPlugin, err := importer.Register(sdk.Deps{DatabaseURL: unreachable})
-	if err != nil {
-		t.Fatalf("registering importer: %v", err)
-	}
-	t.Cleanup(func() { _ = importerPlugin.Stop(context.Background()) })
-	return []sdk.Plugin{whatsappPlugin, importerPlugin}
+	return []sdk.Plugin{whatsappPlugin}
 }
 
 // addUser stores another user and returns its id.
@@ -200,4 +271,16 @@ func (w *world) seedContact(ctx context.Context, name string) (uuid.UUID, error)
 	}
 	w.lastContact = created.ID
 	return created.ID, nil
+}
+
+// seedReachableContact stores a contact owning an email identity.
+func (w *world) seedReachableContact(ctx context.Context, name, email string) error {
+	created, _, err := w.resolver.CreateWithIdentities(ctx, name, []contact.Address{
+		{Channel: contact.Channel("email"), Identifier: email},
+	})
+	if err != nil {
+		return fmt.Errorf("storing the reachable contact: %w", err)
+	}
+	w.lastContact = created.ID
+	return nil
 }


### PR DESCRIPTION
Closes #54.

A spreadsheet column maps onto a field you defined yourself, the same way it maps onto Name, Email and Phone. Import a file with a birth date column and the contacts arrive with their birth dates already on them.

The importer never imports the fields plugin. A new seam, `sdk.FieldProvider`, lets any plugin serve live fields and write their values from text, and `sdk.FieldConsumer` receives them. The host collects providers after registration and hands them to consumers, in `run` and in `seed` both, following the `fieldSources` precedent. With no provider registered the importer serves the three core columns exactly as before.

The fields plugin owns reading text. A CSV cell is text and the value store holds typed values, so someone has to read `420` as a number and `yes` as a boolean. That is kind semantics, so it lives beside `coerce` and reuses it, which keeps the Int range rule and the strict date format in one place.

Cells are checked before a contact is created, so a bad date fails the row and creates nothing. A row matching a contact you already have is skipped and its fields are left untouched, because an import creates and never updates.

### Testing

Needs a `.env` with `ALPHONE_DATABASE_URL`, copied from `.env.example`.

1. Seed and serve. The demo import now carries a Birth date column.

   ```sh
   make seed
   make demo
   ```

2. Log in at http://localhost:8080 as `admin@example.com` with `password1234`.

3. Open **Import** and then `spring-leads.csv`. The rows show four columns and the mapping lists Birth date. Open **Contacts**, then Grace Hopper. Her Fields section holds `1906-12-09`, filled by the import rather than typed in.

4. Now do it yourself. Open **Fields** and add one: label `Joined on`, name `joinedOn`, kind Date. Save.

5. Open **Import** and upload a file with this content, saved as `joined.csv`:

   ```
   Full name,Email address,Joined
   Maria Perez,maria@example.com,2026-03-01
   ```

6. Open the import. Map Full name onto Name, Email address onto Email, and Joined onto **Joined on**. Save mapping, then Commit. The row reads `imported`.

7. Open **Contacts**, then Maria Perez. Joined on holds `2026-03-01`.

8. Check the refusals. Each should be readable and each should leave the data alone.

- Upload a file whose Joined column says `not a date`, map it the same way and commit. The row reads `failed`, the reason names the field and DATE, and no contact is created for it.
- Upload a file whose row repeats an email a contact already owns, with a different Joined value. The row reads `skipped` and that contact's Joined on is unchanged.
- Leave a Joined cell empty. The contact is created and the field stays empty.
- Map a column onto Joined on, then archive the field from **Fields** before pressing Commit. The commit is refused, names `joinedOn`, and the import stays editable so you can re-map it.

9. Prove it reached the API. In a second terminal:

   ```sh
   curl -s http://localhost:8080/api/graphql \
     -H 'Content-Type: application/json' \
     -H "Authorization: Bearer a1_..." \
     -d '{"query":"{ contacts(first: 5) { edges { node { name joinedOn } } } }"}'
   ```

 Mint the token with `go run ./cmd/alphone token create -email admin@example.com -name pr`.

### Worth a second pair of eyes

The commit entry check runs before the claim, not after. `importCommit` used to take its mapping from `claimForCommit`, which flips the import to `committing` first. Refusing after that point would strand the import: the mapping is locked in `committing` and every retry refuses again. So the check reads the stored mapping while the import is still `ready`, and a resumed commit skips it on purpose and converges through the per row checks instead.

Field values are written only when the create reports the contact as newly made. The lost race settles as a skip and writes nothing, the same as the claimant path.

Two changes were not in the plan and are worth naming. The seed refuses a missing demo field only when a provider is registered, because refusing unconditionally would make the fields plugin mandatory for `make seed`. And the development database now runs with `max_connections=300`. `go test ./...` peaked at 104 connections against the default 100 and failed intermittently. That was measured as pre existing, the suite fails the same way with the new feature package excluded.

## Future direction

1. Sorting or filtering the contact list by a field. 
2. Writing fields onto contacts an import matches, once merge review exists. 
3. A field kind for choices with a fixed option list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import CSV and Excel columns into custom contact fields.
  * Map values to date, number, boolean, and other available fields.
  * Automatically convert and validate imported values before saving.
  * Preserve existing field values when rows are skipped.
  * Demo imports now include contact birth dates.

* **Bug Fixes**
  * Invalid values and unavailable fields are reported without partial saves.
  * Archived or removed fields are prevented from receiving imported values.

* **Documentation**
  * Added guidance for mapping spreadsheet columns to custom contact fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->