### PR TITLE
feat: Every caller stands in a tenant

### DIFF
--- a/cmd/alphone/main_exec_test.go
+++ b/cmd/alphone/main_exec_test.go
@@ -298,6 +298,10 @@ type graphAnswer struct {
 		CreateContact struct {
 			ID string `json:"id"`
 		} `json:"createContact"`
+		Tenant struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"tenant"`
 		ImportUpload struct {
 			ID string `json:"id"`
 		} `json:"importUpload"`
@@ -482,6 +486,21 @@ func TestMainBinaryServesARuntimeDefinedField(t *testing.T) {
 	node := read.Data.Contacts.Edges[0].Node
 	if _, selected := node["birthDate"]; !selected {
 		t.Errorf("node = %v, want birthDate answered by the running binary's widened schema", node)
+	}
+}
+
+func TestMainBinaryAnswersTheCallersTenant(t *testing.T) {
+	t.Parallel()
+
+	addr, secret := servedBinary(t, testDatabaseURL(t))
+
+	read := postGraph(t, addr, secret, `{"query":"{ tenant { id name } }"}`)
+
+	if read.Data.Tenant.Name != "Default" {
+		t.Errorf("tenant = %q, want Default answered by the running binary", read.Data.Tenant.Name)
+	}
+	if read.Data.Tenant.ID == "" {
+		t.Error("the tenant carries no id, want the fixed default identifier")
 	}
 }
 

--- a/cmd/alphone/run.go
+++ b/cmd/alphone/run.go
@@ -95,6 +95,7 @@ func run(
 		Contacts:     contacts,
 		Tasks:        tasks,
 		Webhooks:     webhooks,
+		Tenants:      postgres.NewTenantStore(pool),
 		Events:       events,
 		Live:         hub,
 		Auth:         auth,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gopherium/alphone
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/99designs/gqlgen v0.17.94

--- a/graph/budget_test.go
+++ b/graph/budget_test.go
@@ -13,7 +13,7 @@ import (
 
 // Root field budgets per schema owner.
 const (
-	coreRootFieldBudget   = 20
+	coreRootFieldBudget   = 21
 	pluginRootFieldBudget = 10
 )
 

--- a/graph/generated.go
+++ b/graph/generated.go
@@ -188,6 +188,7 @@ type ComplexityRoot struct {
 		Me                    func(childComplexity int) int
 		Task                  func(childComplexity int, id uuid.UUID) int
 		Tasks                 func(childComplexity int, date *time.Time, dueBefore *time.Time, contactID *uuid.UUID, status *string, first *int, after *string) int
+		Tenant                func(childComplexity int) int
 		Users                 func(childComplexity int) int
 		Version               func(childComplexity int) int
 		Webhooks              func(childComplexity int) int
@@ -223,6 +224,11 @@ type ComplexityRoot struct {
 	TaskEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
+	}
+
+	Tenant struct {
+		ID   func(childComplexity int) int
+		Name func(childComplexity int) int
 	}
 
 	User struct {
@@ -311,6 +317,7 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	Version(ctx context.Context) (string, error)
+	Tenant(ctx context.Context) (*model.Tenant, error)
 	Me(ctx context.Context) (*model.Identity, error)
 	Users(ctx context.Context) ([]*model.User, error)
 	Contacts(ctx context.Context, q *string, first *int, after *string) (*model.ContactConnection, error)
@@ -1055,6 +1062,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.Tasks(childComplexity, args["date"].(*time.Time), args["dueBefore"].(*time.Time), args["contactId"].(*uuid.UUID), args["status"].(*string), args["first"].(*int), args["after"].(*string)), true
+	case "Query.tenant":
+		if e.ComplexityRoot.Query.Tenant == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Query.Tenant(childComplexity), true
 	case "Query.users":
 		if e.ComplexityRoot.Query.Users == nil {
 			break
@@ -1212,6 +1225,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.TaskEdge.Node(childComplexity), true
+
+	case "Tenant.id":
+		if e.ComplexityRoot.Tenant.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Tenant.ID(childComplexity), true
+	case "Tenant.name":
+		if e.ComplexityRoot.Tenant.Name == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Tenant.Name(childComplexity), true
 
 	case "User.createdAt":
 		if e.ComplexityRoot.User.CreatedAt == nil {
@@ -1957,6 +1983,16 @@ func (ec *executionContext) childFields_TaskEdge(ctx context.Context, field grap
 		return ec.fieldContext_TaskEdge_cursor(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type TaskEdge", field.Name)
+}
+
+func (ec *executionContext) childFields_Tenant(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "id":
+		return ec.fieldContext_Tenant_id(ctx, field)
+	case "name":
+		return ec.fieldContext_Tenant_name(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type Tenant", field.Name)
 }
 
 func (ec *executionContext) childFields_User(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -5315,6 +5351,38 @@ func (ec *executionContext) fieldContext_Query_version(_ context.Context, field 
 	return graphql.NewScalarFieldContext("Query", field, true, true, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _Query_tenant(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_tenant(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Query().Tenant(ctx)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Tenant) graphql.Marshaler {
+			return ec.marshalNTenant2ᚖgithubᚗcomᚋgopheriumᚋalphoneᚋgraphᚋmodelᚐTenant(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_tenant(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Tenant(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_me(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -6372,6 +6440,52 @@ func (ec *executionContext) _TaskEdge_cursor(ctx context.Context, field graphql.
 }
 func (ec *executionContext) fieldContext_TaskEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("TaskEdge", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Tenant_id(ctx context.Context, field graphql.CollectedField, obj *model.Tenant) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Tenant_id(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v uuid.UUID) graphql.Marshaler {
+			return ec.marshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Tenant_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Tenant", field, false, false, errors.New("field of type UUID does not have child fields"))
+}
+
+func (ec *executionContext) _Tenant_name(ctx context.Context, field graphql.CollectedField, obj *model.Tenant) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Tenant_name(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Name, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Tenant_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Tenant", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -9696,6 +9810,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "tenant":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_tenant(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "me":
 			field := field
 
@@ -10224,6 +10360,49 @@ func (ec *executionContext) _TaskEdge(ctx context.Context, sel ast.SelectionSet,
 			}
 		case "cursor":
 			out.Values[i] = ec._TaskEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferLabelToView), math.MaxInt32)))
+
+	ec.ProcessDeferredGroup(graphql.DeferredGroup{
+		Defers:   deferLabelToView,
+		Path:     graphql.GetPath(ctx),
+		FieldSet: deferredFieldSet,
+		Context:  ctx,
+	})
+
+	return out
+}
+
+var tenantImplementors = []string{"Tenant"}
+
+func (ec *executionContext) _Tenant(ctx context.Context, sel ast.SelectionSet, obj *model.Tenant) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tenantImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferredFieldSet := graphql.NewFieldSet(nil)
+	deferLabelToView := make(map[string]*graphql.FieldSetView)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Tenant")
+		case "id":
+			out.Values[i] = ec._Tenant_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._Tenant_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11608,6 +11787,20 @@ func (ec *executionContext) marshalNTaskEdge2ᚖgithubᚗcomᚋgopheriumᚋalpho
 		return graphql.Null
 	}
 	return ec._TaskEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTenant2githubᚗcomᚋgopheriumᚋalphoneᚋgraphᚋmodelᚐTenant(ctx context.Context, sel ast.SelectionSet, v model.Tenant) graphql.Marshaler {
+	return ec._Tenant(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTenant2ᚖgithubᚗcomᚋgopheriumᚋalphoneᚋgraphᚋmodelᚐTenant(ctx context.Context, sel ast.SelectionSet, v *model.Tenant) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Tenant(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, v any) (uuid.UUID, error) {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -175,6 +175,11 @@ type TaskEdge struct {
 	Cursor string `json:"cursor"`
 }
 
+type Tenant struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+}
+
 type UpdateTaskInput struct {
 	Title    *string    `json:"title,omitempty"`
 	DueOn    *time.Time `json:"dueOn,omitempty"`

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -144,6 +144,7 @@ type PageInfo {
 }
 type Query {
 	version: String!
+	tenant: Tenant!
 	me: Identity!
 	users: [User!]!
 	contacts(q: String, first: Int, after: String): ContactConnection!
@@ -183,6 +184,10 @@ type TaskConnection {
 type TaskEdge {
 	node: Task!
 	cursor: String!
+}
+type Tenant {
+	id: UUID!
+	name: String!
 }
 scalar UUID
 input UpdateTaskInput {

--- a/graph/schema/core.graphqls
+++ b/graph/schema/core.graphqls
@@ -17,8 +17,14 @@ type PageInfo {
   endCursor: String
 }
 
+type Tenant {
+  id: UUID!
+  name: String!
+}
+
 type Query {
   version: String!
+  tenant: Tenant!
 }
 
 type Subscription {

--- a/internal/graphres/graphres.go
+++ b/internal/graphres/graphres.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/gopherium/gouncer/authkit"
 
+	"github.com/gopherium/alphone/graph/model"
 	"github.com/gopherium/alphone/internal/contact"
 	"github.com/gopherium/alphone/internal/event"
 	"github.com/gopherium/alphone/internal/task"
+	"github.com/gopherium/alphone/internal/tenant"
 	"github.com/gopherium/alphone/internal/webhook"
 )
 
@@ -46,6 +48,11 @@ type TaskStore interface {
 	) ([]task.Task, error)
 	Create(ctx context.Context, t task.Task) (task.Task, bool, error)
 	Update(ctx context.Context, t task.Task) (task.Task, error)
+}
+
+// TenantStore reads the tenant a caller stands in.
+type TenantStore interface {
+	TenantForUser(ctx context.Context, userID uuid.UUID) (tenant.Tenant, error)
 }
 
 // WebhookStore provides the webhook subscriptions the graph manages.
@@ -82,6 +89,8 @@ type Resolver struct {
 	Tasks TaskStore
 	// Webhooks serves the webhook subscriptions.
 	Webhooks WebhookStore
+	// Tenants serves the caller's own tenant.
+	Tenants TenantStore
 	// Events announces domain events. Nil publishes nothing.
 	Events Publisher
 	// Live hands subscriptions the frames they may see. Nil serves no subscription.
@@ -137,4 +146,13 @@ type QueryResolvers struct {
 // Version reports the application version.
 func (q QueryResolvers) Version(context.Context) (string, error) {
 	return q.root.Version, nil
+}
+
+// Tenant answers the caller's own tenant.
+func (q QueryResolvers) Tenant(ctx context.Context) (*model.Tenant, error) {
+	held, err := q.root.Tenants.TenantForUser(ctx, authkit.IdentityFromContext(ctx).ID)
+	if err != nil {
+		return nil, err
+	}
+	return &model.Tenant{ID: held.ID, Name: held.Name}, nil
 }

--- a/internal/graphres/tenants_test.go
+++ b/internal/graphres/tenants_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package graphres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gopherium/alphone/internal/graphres"
+	"github.com/gopherium/alphone/internal/postgres"
+	"github.com/gopherium/alphone/internal/tenant"
+)
+
+var errTenantStore = errors.New("the tenant store is unreachable")
+
+// failingTenantStore refuses every lookup.
+type failingTenantStore struct{}
+
+// TenantForUser reports the store failure.
+func (failingTenantStore) TenantForUser(context.Context, uuid.UUID) (tenant.Tenant, error) {
+	return tenant.Tenant{}, errTenantStore
+}
+
+// tenantRead is the answer shape of the tenant query.
+type tenantRead struct {
+	Tenant struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"tenant"`
+}
+
+func TestTenantAnswersTheDefaultForAnUnplacedCaller(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	resolver := &graphres.Resolver{Version: "test", Tenants: postgres.NewTenantStore(pool)}
+	client := newGraphClient(t, resolver, uuid.Must(uuid.NewV7()))
+
+	var read tenantRead
+	client.MustPost(`{ tenant { id name } }`, &read)
+
+	if read.Tenant.ID != tenant.DefaultID.String() {
+		t.Errorf("id = %s, want the default tenant", read.Tenant.ID)
+	}
+	if read.Tenant.Name != "Default" {
+		t.Errorf("name = %q, want Default", read.Tenant.Name)
+	}
+}
+
+func TestTenantAnswersThePlacedTenant(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	caller := uuid.Must(uuid.NewV7())
+	acme := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenant_members (user_id, tenant_id) VALUES ($1, $2)", caller, acme); err != nil {
+		t.Fatalf("placing the member: %v", err)
+	}
+	resolver := &graphres.Resolver{Version: "test", Tenants: postgres.NewTenantStore(pool)}
+	client := newGraphClient(t, resolver, caller)
+
+	var read tenantRead
+	client.MustPost(`{ tenant { id name } }`, &read)
+
+	if read.Tenant.ID != acme.String() || read.Tenant.Name != "Acme" {
+		t.Errorf("tenant = %+v, want the placed Acme tenant", read.Tenant)
+	}
+}
+
+func TestTenantReportsAStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	resolver := &graphres.Resolver{Version: "test", Tenants: failingTenantStore{}}
+	client := newGraphClient(t, resolver, uuid.Must(uuid.NewV7()))
+
+	var read tenantRead
+	err := client.Post(`{ tenant { id name } }`, &read)
+
+	if err == nil {
+		t.Error("Post() error = nil, want the store failure surfaced")
+	}
+}

--- a/internal/postgres/db/models.go
+++ b/internal/postgres/db/models.go
@@ -48,6 +48,18 @@ type CoreTask struct {
 	CreatedAt     time.Time
 }
 
+type CoreTenant struct {
+	ID        uuid.UUID
+	Name      string
+	CreatedAt time.Time
+}
+
+type CoreTenantMember struct {
+	UserID    uuid.UUID
+	TenantID  uuid.UUID
+	CreatedAt time.Time
+}
+
 type CoreWebhookDelivery struct {
 	ID             uuid.UUID
 	SubscriptionID uuid.UUID

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -850,6 +850,32 @@ func (q *Queries) SettleWebhookDelivery(ctx context.Context, arg SettleWebhookDe
 	return err
 }
 
+const tenantForUser = `-- name: TenantForUser :one
+SELECT t.id, t.name
+FROM core.tenants t
+LEFT JOIN core.tenant_members m ON m.tenant_id = t.id AND m.user_id = $1::uuid
+WHERE m.user_id IS NOT NULL OR t.id = $2::uuid
+ORDER BY m.user_id IS NOT NULL DESC
+LIMIT 1
+`
+
+type TenantForUserParams struct {
+	UserID    uuid.UUID
+	DefaultID uuid.UUID
+}
+
+type TenantForUserRow struct {
+	ID   uuid.UUID
+	Name string
+}
+
+func (q *Queries) TenantForUser(ctx context.Context, arg TenantForUserParams) (TenantForUserRow, error) {
+	row := q.db.QueryRow(ctx, tenantForUser, arg.UserID, arg.DefaultID)
+	var i TenantForUserRow
+	err := row.Scan(&i.ID, &i.Name)
+	return i, err
+}
+
 const touchAPIToken = `-- name: TouchAPIToken :exec
 UPDATE core.api_tokens
 SET last_used_at = $2

--- a/internal/postgres/migrations/00011_create_tenants.sql
+++ b/internal/postgres/migrations/00011_create_tenants.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: Elastic-2.0
+
+-- +goose Up
+CREATE TABLE core.tenants (
+    id uuid PRIMARY KEY,
+    name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE core.tenant_members (
+    user_id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL REFERENCES core.tenants (id),
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO core.tenants (id, name)
+VALUES ('00000000-0000-7000-8000-000000000001', 'Default')
+ON CONFLICT (id) DO NOTHING;
+
+-- +goose Down
+DROP TABLE core.tenant_members;
+
+DROP TABLE core.tenants;

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -190,3 +190,11 @@ WHERE id = $1;
 SELECT id, name, created_at
 FROM core.contacts
 WHERE id = ANY(@ids::uuid[]);
+
+-- name: TenantForUser :one
+SELECT t.id, t.name
+FROM core.tenants t
+LEFT JOIN core.tenant_members m ON m.tenant_id = t.id AND m.user_id = @user_id::uuid
+WHERE m.user_id IS NOT NULL OR t.id = @default_id::uuid
+ORDER BY m.user_id IS NOT NULL DESC
+LIMIT 1;

--- a/internal/postgres/tenants.go
+++ b/internal/postgres/tenants.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/alphone/internal/postgres/db"
+	"github.com/gopherium/alphone/internal/tenant"
+)
+
+// TenantStore reads the tenant a user stands in.
+type TenantStore struct {
+	queries *db.Queries
+}
+
+// NewTenantStore returns a TenantStore backed by pool.
+func NewTenantStore(pool *pgxpool.Pool) *TenantStore {
+	return &TenantStore{queries: db.New(pool)}
+}
+
+// TenantForUser returns the user's tenant, the default when no row places them.
+func (s *TenantStore) TenantForUser(ctx context.Context, userID uuid.UUID) (tenant.Tenant, error) {
+	row, err := s.queries.TenantForUser(ctx, db.TenantForUserParams{
+		UserID:    userID,
+		DefaultID: tenant.DefaultID,
+	})
+	if err != nil {
+		return tenant.Tenant{}, fmt.Errorf("read tenant: %w", err)
+	}
+	return tenant.Tenant{ID: row.ID, Name: row.Name}, nil
+}

--- a/internal/postgres/tenants_test.go
+++ b/internal/postgres/tenants_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package postgres_test
+
+import (
+	"database/sql"
+	"io/fs"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/database"
+
+	"github.com/gopherium/alphone/internal/postgres"
+	"github.com/gopherium/alphone/internal/tenant"
+	"github.com/gopherium/alphone/internal/testdb"
+)
+
+func TestTenantForUserAnswersTheDefaultWithoutARow(t *testing.T) {
+	t.Parallel()
+
+	store := postgres.NewTenantStore(newTestPool(t))
+
+	got, err := store.TenantForUser(t.Context(), uuid.Must(uuid.NewV7()))
+
+	if err != nil {
+		t.Fatalf("TenantForUser() error = %v, want nil", err)
+	}
+	if got.ID != tenant.DefaultID {
+		t.Errorf("id = %s, want the default tenant %s", got.ID, tenant.DefaultID)
+	}
+	if got.Name != "Default" {
+		t.Errorf("name = %q, want Default", got.Name)
+	}
+}
+
+func TestTenantForUserAnswersThePlacedTenant(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	store := postgres.NewTenantStore(pool)
+	acme := uuid.Must(uuid.NewV7())
+	member := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenant_members (user_id, tenant_id) VALUES ($1, $2)", member, acme); err != nil {
+		t.Fatalf("placing the member: %v", err)
+	}
+
+	got, err := store.TenantForUser(t.Context(), member)
+
+	if err != nil {
+		t.Fatalf("TenantForUser() error = %v, want nil", err)
+	}
+	if got.ID != acme || got.Name != "Acme" {
+		t.Errorf("tenant = %+v, want the placed Acme tenant", got)
+	}
+}
+
+func TestMigrationSeedsTheDefaultTenantExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+
+	var held int
+	if err := pool.QueryRow(t.Context(),
+		"SELECT count(*) FROM core.tenants WHERE id = $1", tenant.DefaultID).Scan(&held); err != nil {
+		t.Fatalf("reading the default tenant: %v", err)
+	}
+
+	if held != 1 {
+		t.Errorf("the store holds %d default tenants, want exactly 1", held)
+	}
+}
+
+func TestTenantsMigrationUpgradesAnExistingDatabase(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+
+	cfg := pgtestdb.Custom(t, testdb.Config(), pgtestdb.NoopMigrator{})
+	db, err := sql.Open("pgx", cfg.URL())
+	if err != nil {
+		t.Fatalf("opening the database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	provider := newCoreProvider(t, db)
+	if _, err := provider.UpTo(t.Context(), 10); err != nil {
+		t.Fatalf("migrating to the previous version: %v", err)
+	}
+	var missing *string
+	if err := db.QueryRowContext(t.Context(),
+		"SELECT to_regclass('core.tenants')::text").Scan(&missing); err != nil {
+		t.Fatalf("probing the relation: %v", err)
+	}
+	if missing != nil {
+		t.Fatal("core.tenants exists before its migration, the version pin is wrong")
+	}
+
+	if _, err := provider.Up(t.Context()); err != nil {
+		t.Fatalf("migrating forward: %v", err)
+	}
+
+	var name string
+	if err := db.QueryRowContext(t.Context(),
+		"SELECT name FROM core.tenants WHERE id = $1", tenant.DefaultID).Scan(&name); err != nil {
+		t.Fatalf("reading the default tenant: %v", err)
+	}
+	if name != "Default" {
+		t.Errorf("name = %q, want Default on an upgraded database", name)
+	}
+}
+
+// newCoreProvider builds a goose provider over the embedded core migrations.
+func newCoreProvider(t *testing.T, db *sql.DB) *goose.Provider {
+	t.Helper()
+	store, err := database.NewStore(database.DialectPostgres, "goose_db_version")
+	if err != nil {
+		t.Fatalf("building the migration store: %v", err)
+	}
+	source, err := fs.Sub(postgres.Migrations, "migrations")
+	if err != nil {
+		t.Fatalf("opening the migration source: %v", err)
+	}
+	provider, err := goose.NewProvider("", db, source, goose.WithStore(store))
+	if err != nil {
+		t.Fatalf("building the migration provider: %v", err)
+	}
+	return provider
+}
+
+func TestTenantForUserReportsAStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	store := postgres.NewTenantStore(pool)
+	pool.Close()
+
+	if _, err := store.TenantForUser(t.Context(), uuid.Must(uuid.NewV7())); err == nil {
+		t.Error("TenantForUser() error = nil, want the closed pool reported")
+	}
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+// Package tenant defines the tenant a caller stands in.
+package tenant
+
+import "github.com/google/uuid"
+
+// DefaultID identifies the tenant every unplaced user belongs to.
+var DefaultID = uuid.MustParse("00000000-0000-7000-8000-000000000001")
+
+// Tenant is one organization served by the install.
+type Tenant struct {
+	ID   uuid.UUID
+	Name string
+}

--- a/test/features/features/tenants.feature
+++ b/test/features/features/tenants.feature
@@ -6,30 +6,25 @@ Feature: Every caller stands in a tenant
   Background:
     Given a running AlphOne holding a user with an API token
 
-  @wip
   Scenario: A fresh install holds the default tenant
     Then the store holds the tenant "Default"
 
-  @wip
   Scenario: A caller without a membership row is answered the default tenant
     When the caller asks for its tenant
     Then the tenant answered is "Default"
 
-  @wip
   Scenario: A member of another tenant is answered that tenant
     Given the tenant "Acme" exists
     And the caller is placed in the tenant "Acme"
     When the caller asks for its tenant
     Then the tenant answered is "Acme"
 
-  @wip
   Scenario: An API token caller is answered its own user's tenant
     Given the tenant "Globex" exists
     And a user "grace.hopper@example.com" holding a token is placed in the tenant "Globex"
     When that token asks for its tenant
     Then the tenant answered is "Globex"
 
-  @wip
   Scenario: An anonymous caller is refused before the field
     When an anonymous caller asks for a tenant
     Then the ask is refused as unauthenticated

--- a/test/features/features/tenants.feature
+++ b/test/features/features/tenants.feature
@@ -1,0 +1,35 @@
+Feature: Every caller stands in a tenant
+  A fresh install holds one default tenant and every user belongs to it
+  without a row saying so. Membership rows exist only for users placed
+  somewhere else, and the graph answers each caller its own tenant.
+
+  Background:
+    Given a running AlphOne holding a user with an API token
+
+  @wip
+  Scenario: A fresh install holds the default tenant
+    Then the store holds the tenant "Default"
+
+  @wip
+  Scenario: A caller without a membership row is answered the default tenant
+    When the caller asks for its tenant
+    Then the tenant answered is "Default"
+
+  @wip
+  Scenario: A member of another tenant is answered that tenant
+    Given the tenant "Acme" exists
+    And the caller is placed in the tenant "Acme"
+    When the caller asks for its tenant
+    Then the tenant answered is "Acme"
+
+  @wip
+  Scenario: An API token caller is answered its own user's tenant
+    Given the tenant "Globex" exists
+    And a user "grace.hopper@example.com" holding a token is placed in the tenant "Globex"
+    When that token asks for its tenant
+    Then the tenant answered is "Globex"
+
+  @wip
+  Scenario: An anonymous caller is refused before the field
+    When an anonymous caller asks for a tenant
+    Then the ask is refused as unauthenticated

--- a/test/features/features_test.go
+++ b/test/features/features_test.go
@@ -73,6 +73,11 @@ func initializeFieldsGraph(t *testing.T) func(*godog.ScenarioContext) {
 	return func(sc *godog.ScenarioContext) { registerFieldsGraphSteps(sc, t) }
 }
 
+// initializeTenants registers the tenant seam steps.
+func initializeTenants(t *testing.T) func(*godog.ScenarioContext) {
+	return func(sc *godog.ScenarioContext) { registerTenantSteps(sc, t) }
+}
+
 // initializeImportFields registers the import mapping steps.
 func initializeImportFields(t *testing.T) func(*godog.ScenarioContext) {
 	return func(sc *godog.ScenarioContext) { registerImportFieldsSteps(sc, t) }
@@ -104,6 +109,10 @@ func TestFieldsValues(t *testing.T) {
 
 func TestFieldsGraph(t *testing.T) {
 	runFeature(t, "features/fields-graph.feature", initializeFieldsGraph(t))
+}
+
+func TestTenants(t *testing.T) {
+	runFeature(t, "features/tenants.feature", initializeTenants(t))
 }
 
 func TestImportFields(t *testing.T) {

--- a/test/features/steps_tenants_test.go
+++ b/test/features/steps_tenants_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package features_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cucumber/godog"
+)
+
+// tenantQuery reads the caller's own tenant.
+const tenantQuery = `{"query":"{ tenant { id name } }"}`
+
+// tenantAnswer is the envelope every tenant step reads.
+type tenantAnswer struct {
+	Data struct {
+		Tenant struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"tenant"`
+	} `json:"data"`
+	Errors []struct {
+		Message    string         `json:"message"`
+		Extensions map[string]any `json:"extensions"`
+	} `json:"errors"`
+}
+
+// postGraphWith posts a graph request carrying the given bearer secret, empty for none.
+func (w *world) postGraphWith(ctx context.Context, secret, body string) ([]byte, error) {
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, w.server.URL+"/api/graphql", strings.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building the graph request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	if secret != "" {
+		request.Header.Set("Authorization", "Bearer "+secret)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("posting the graph request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	answered, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading the graph answer: %w", err)
+	}
+	w.answered = answered
+	return answered, nil
+}
+
+// askTenant reads the tenant the given secret's caller stands in.
+func (w *world) askTenant(ctx context.Context, secret string) error {
+	_, err := w.postGraphWith(ctx, secret, tenantQuery)
+	return err
+}
+
+// registerTenantSteps binds the tenant steps and the world lifecycle.
+func registerTenantSteps(sc *godog.ScenarioContext, t *testing.T) {
+	sc.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
+		return context.WithValue(ctx, worldKey{}, newWorld(t)), nil
+	})
+
+	sc.Given(`^a running AlphOne holding a user with an API token$`, func(ctx context.Context) error {
+		if worldFrom(ctx).secret == "" {
+			return fmt.Errorf("the scenario holds no token")
+		}
+		return nil
+	})
+
+	sc.Given(`^the tenant "([^"]*)" exists$`, func(ctx context.Context, name string) error {
+		_, err := worldFrom(ctx).seedTenant(ctx, name)
+		return err
+	})
+
+	sc.Given(`^the caller is placed in the tenant "([^"]*)"$`,
+		func(ctx context.Context, name string) error {
+			w := worldFrom(ctx)
+			return w.placeMember(ctx, w.ownerID, name)
+		})
+
+	sc.Given(`^a user "([^"]*)" holding a token is placed in the tenant "([^"]*)"$`,
+		func(ctx context.Context, email, name string) error {
+			w := worldFrom(ctx)
+			userID, err := w.addUser(ctx, email, "Grace Hopper")
+			if err != nil {
+				return err
+			}
+			secret, err := w.mintSecretFor(ctx, userID, "tenant scenario")
+			if err != nil {
+				return err
+			}
+			w.altSecret = secret
+			return w.placeMember(ctx, userID, name)
+		})
+
+	sc.When(`^the caller asks for its tenant$`, func(ctx context.Context) error {
+		w := worldFrom(ctx)
+		return w.askTenant(ctx, w.secret)
+	})
+
+	sc.When(`^that token asks for its tenant$`, func(ctx context.Context) error {
+		w := worldFrom(ctx)
+		if w.altSecret == "" {
+			return fmt.Errorf("the scenario minted no second token")
+		}
+		return w.askTenant(ctx, w.altSecret)
+	})
+
+	sc.When(`^an anonymous caller asks for a tenant$`, func(ctx context.Context) error {
+		return worldFrom(ctx).askTenant(ctx, "")
+	})
+
+	sc.Then(`^the store holds the tenant "([^"]*)"$`, func(ctx context.Context, name string) error {
+		w := worldFrom(ctx)
+		var held int
+		if err := w.pool.QueryRow(ctx,
+			"SELECT count(*) FROM core.tenants WHERE name = $1", name).Scan(&held); err != nil {
+			return fmt.Errorf("reading the tenants: %w", err)
+		}
+		if held != 1 {
+			return fmt.Errorf("the store holds %d tenants named %q, want 1", held, name)
+		}
+		return nil
+	})
+
+	sc.Then(`^the tenant answered is "([^"]*)"$`, func(ctx context.Context, name string) error {
+		w := worldFrom(ctx)
+		var answer tenantAnswer
+		if err := json.Unmarshal(w.answered, &answer); err != nil {
+			return fmt.Errorf("decoding %s: %w", w.answered, err)
+		}
+		if len(answer.Errors) > 0 {
+			return fmt.Errorf("the graph refused the read, answered %s", w.answered)
+		}
+		if answer.Data.Tenant.Name != name {
+			return fmt.Errorf("tenant = %q, want %q, answered %s", answer.Data.Tenant.Name, name, w.answered)
+		}
+		if answer.Data.Tenant.ID == "" {
+			return fmt.Errorf("the tenant carries no id, answered %s", w.answered)
+		}
+		return nil
+	})
+
+	sc.Then(`^the ask is refused as unauthenticated$`, func(ctx context.Context) error {
+		w := worldFrom(ctx)
+		var answer tenantAnswer
+		if err := json.Unmarshal(w.answered, &answer); err != nil {
+			return fmt.Errorf("decoding %s: %w", w.answered, err)
+		}
+		if len(answer.Errors) == 0 {
+			return fmt.Errorf("the graph accepted the anonymous ask, answered %s", w.answered)
+		}
+		if got := answer.Errors[0].Extensions["code"]; got != "UNAUTHENTICATED" {
+			return fmt.Errorf("code = %v, want UNAUTHENTICATED, answered %s", got, w.answered)
+		}
+		return nil
+	})
+}

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -66,6 +66,7 @@ type world struct {
 	captured    []byte
 	answered    []byte
 	lastField   uuid.UUID
+	altSecret   string
 }
 
 // newWorld boots an isolated database and a real server for one scenario.
@@ -308,6 +309,47 @@ func (w *world) seedContact(ctx context.Context, name string) (uuid.UUID, error)
 	}
 	w.lastContact = created.ID
 	return created.ID, nil
+}
+
+// seedTenant stores a tenant and returns its id.
+func (w *world) seedTenant(ctx context.Context, name string) (uuid.UUID, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("generating the tenant id: %w", err)
+	}
+	if _, err := w.pool.Exec(ctx,
+		"INSERT INTO core.tenants (id, name, created_at) VALUES ($1, $2, now())", id, name); err != nil {
+		return uuid.Nil, fmt.Errorf("storing the tenant: %w", err)
+	}
+	return id, nil
+}
+
+// placeMember upserts one user's membership into the named tenant.
+func (w *world) placeMember(ctx context.Context, userID uuid.UUID, tenantName string) error {
+	tag, err := w.pool.Exec(ctx,
+		`INSERT INTO core.tenant_members (user_id, tenant_id, created_at)
+		SELECT $1, id, now() FROM core.tenants WHERE name = $2
+		ON CONFLICT (user_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id`,
+		userID, tenantName)
+	if err != nil {
+		return fmt.Errorf("placing the member: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("no tenant named %q holds a row", tenantName)
+	}
+	return nil
+}
+
+// mintSecretFor mints and stores an API token for the given user.
+func (w *world) mintSecretFor(ctx context.Context, userID uuid.UUID, name string) (string, error) {
+	minted, err := apitoken.Mint(userID, name)
+	if err != nil {
+		return "", fmt.Errorf("minting the token: %w", err)
+	}
+	if err := postgres.NewTokenStore(w.pool).Create(ctx, minted.Token); err != nil {
+		return "", fmt.Errorf("storing the token: %w", err)
+	}
+	return minted.Secret, nil
 }
 
 // seedReachableContact stores a contact owning an email identity.

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -115,6 +115,7 @@ func bootWorld(t *testing.T, liveImports bool) *world {
 		Contacts:     contacts,
 		Tasks:        tasks,
 		Webhooks:     webhooks,
+		Tenants:      postgres.NewTenantStore(pool),
 		Live:         hub,
 		Auth:         auth,
 		Admin:        authkit.NewAdmin(users),


### PR DESCRIPTION
Closes #61.

Every caller now stands in a tenant. A fresh install holds one named Default, every user belongs to it, and the graph answers each caller its own.

Nothing is enrolled anywhere. A user with no membership row is answered the default, which is the whole trick: no backfill migration, no enrollment at the call sites, and no path that can forget a user. Rows exist only for users deliberately placed somewhere else, which is work for a later cycle rather than core's business.

The fallback lives inside the SQL. One left join ordered by membership presence answers either the placed tenant or the default in a single round trip, so no Go branch decides who gets what.

This is the first seam of a longer program. Data scoping, per tenant uniqueness on email and phone identity, and row level security all follow as their own cycles. Nothing existing changes shape, no table gains a column, and no uniqueness rule moves.

### Testing

Needs a `.env` with `ALPHONE_DATABASE_URL`, copied from `.env.example`.

1. Seed and serve.

   ```sh
   make seed
   make demo
   ```

2. Log in at http://localhost:8080 as `admin@example.com` with `password1234`.

3. Nothing visible changes. That is the point, the seam is invisible to an operator until tenant management exists.

4. Ask for the tenant. Mint a token with `go run ./cmd/alphone token create -email admin@example.com -name pr`, then:

   ```sh
   curl -s http://localhost:8080/api/graphql \
     -H 'Content-Type: application/json' \
     -H "Authorization: Bearer a1_..." \
     -d '{"query":"{ tenant { id name } }"}'
   ```

   It answers `Default` at `00000000-0000-7000-8000-000000000001`.

5. Place yourself somewhere else and ask again. The answer follows the row.

   ```sh
   docker compose exec -T postgres psql -U postgres -d alphone -c \
     "INSERT INTO core.tenants (id, name) VALUES (gen_random_uuid(), 'Acme')"
   docker compose exec -T postgres psql -U postgres -d alphone -c \
     "INSERT INTO core.tenant_members (user_id, tenant_id) SELECT u.id, t.id FROM auth.users u, core.tenants t WHERE u.email = 'admin@example.com' AND t.name = 'Acme'"
   ```

   The same curl now answers `Acme`.

6. Check the refusals.

- Ask without the Authorization header. Refused as UNAUTHENTICATED.
- Remove the membership row and ask again. Back to `Default`, no error.

7. Prove an upgrade works, since this migration runs on live installs. Point `ALPHONE_DATABASE_URL` at a database seeded before this branch, start the server, and ask. It answers `Default` without any backfill.

### Worth a second pair of eyes

Resolution happens in the resolver, not in middleware. The graph handler is reached three ways, a session cookie, an API token and the MCP executor posting in process, and only the resolver sits below all three. Middleware on the graphql group would have missed MCP entirely.

The default tenant carries a fixed identifier, pinned in both the migration and `internal/tenant` and tied together by a test. It is v7 shaped with a zero timestamp, so it can never collide with a generated one. It is also public knowledge by design, which makes one rule load bearing for later cycles: a tenant id names a row and never grants access. `Query.tenant` takes no argument and derives everything from the authenticated caller.

The root field budget moved from 20 to 21, a deliberate edit the budget test asks for by name.

Two exec tests guard the wiring, and I proved they have teeth by cutting the store out of `run.go` and watching the real binary answer `internal system error`.

## Future direction

1. Per tenant uniqueness on email and phone identity, which reaches into gouncer. 
2. Tenant columns and row level security on the data tables. 
3. Tenant management, which lives outside core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant information to the GraphQL API, including tenant ID and name.
  * Added tenant resolution for authenticated callers, supporting assigned tenants and a default fallback.
  * Added database support for tenants and user-to-tenant associations.
  * Added tenant handling for API-token requests.

* **Bug Fixes**
  * Unauthenticated tenant requests now return an appropriate access error.

* **Tests**
  * Added end-to-end coverage for tenant resolution, migrations, error handling, and authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->