### PR TITLE
test(frontend): compose the route outline from plugin exports

### DIFF
--- a/frontend/src/test/outline.test.tsx
+++ b/frontend/src/test/outline.test.tsx
@@ -9,17 +9,31 @@ vi.mock('@alphone/frontend-sdk/dataviews', () => ({
 	DataForm: () => <form />,
 }))
 
-import { importID, handlers as importerHandlers } from '@alphone/plugin-importer/handlers'
-import { handlers } from '@alphone/plugin-whatsapp/handlers'
 import { createAppRouter } from '../router'
 import { renderAt } from './render'
 
 const taskID = '0198c000-0000-7000-8000-000000000301'
 const contactID = '0198c000-0000-7000-8000-000000000302'
-const conversationID = '019f4a00-0000-7000-8000-000000000001'
 
-// Every leaf route, with its parameters bound to a fixture the handlers serve.
-const paths: Record<string, string> = {
+/** PluginOutline is the leaf routes and fixtures one plugin contributes to the sweep. */
+interface PluginOutline {
+	paths: Record<string, string>
+	handlers?: Parameters<typeof server.use>
+}
+
+/** pluginOutlines holds every plugin's outline from both plugin roots. */
+const pluginOutlines = Object.values(
+	import.meta.glob(
+		[
+			'../../../plugins/*/frontend/outline.ts',
+			'../../../enterprise/*/frontend/outline.ts',
+		],
+		{ eager: true },
+	),
+) as PluginOutline[]
+
+/** corePaths is every core leaf route, its parameters bound to a served fixture. */
+const corePaths: Record<string, string> = {
 	'/': '/',
 	'/tasks': '/tasks',
 	'/tasks/new': '/tasks/new',
@@ -29,20 +43,18 @@ const paths: Record<string, string> = {
 	'/contacts/$contactId': `/contacts/${contactID}`,
 	'/users': '/users',
 	'/users/new': '/users/new',
-	// The section route holds the sidebar and renders its canvas through the
-	// index child, so both ids resolve to the same URL.
-	'/whatsapp': '/whatsapp',
-	'/whatsapp/': '/whatsapp',
-	'/whatsapp/conversations/$conversationId': `/whatsapp/conversations/${conversationID}`,
-	'/import': '/import',
-	'/import/$importId': `/import/${importID}`,
-	'/fields': '/fields',
 }
+
+/** paths is every leaf route of the composed router, core plus both plugin roots. */
+const paths: Record<string, string> = Object.assign(
+	{},
+	corePaths,
+	...pluginOutlines.map((outline) => outline.paths),
+)
 
 beforeEach(() => {
 	server.use(
-		...handlers,
-		...importerHandlers,
+		...pluginOutlines.flatMap((outline) => outline.handlers ?? []),
 		graphql.query('TaskDetail', () =>
 			HttpResponse.json({
 				data: {

--- a/plugins/fields/frontend/outline.ts
+++ b/plugins/fields/frontend/outline.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+/** The fields leaf routes the outline sweep renders. */
+export const paths: Record<string, string> = {
+	'/fields': '/fields',
+}

--- a/plugins/importer/frontend/outline.ts
+++ b/plugins/importer/frontend/outline.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { handlers, importID } from './handlers'
+
+/** The importer leaf routes the outline sweep renders, bound to served fixtures. */
+export const paths: Record<string, string> = {
+	'/import': '/import',
+	'/import/$importId': `/import/${importID}`,
+}
+
+export { handlers }

--- a/plugins/whatsapp/frontend/handlers.ts
+++ b/plugins/whatsapp/frontend/handlers.ts
@@ -23,10 +23,12 @@ function threadMessage(id: string, externalId: string, fields: Record<string, un
 	}
 }
 
+export const conversationID = '019f4a00-0000-7000-8000-000000000001'
+
 const conversations = [
 	{
 		__typename: 'WhatsAppConversation',
-		id: '019f4a00-0000-7000-8000-000000000001',
+		id: conversationID,
 		status: 'open',
 		lastActivityAt: '2026-07-06T10:05:00Z',
 		lastMessagePreview: 'I can pick it up after 5pm.',

--- a/plugins/whatsapp/frontend/outline.ts
+++ b/plugins/whatsapp/frontend/outline.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { conversationID, handlers } from './handlers'
+
+/** The whatsapp leaf routes the outline sweep renders, bound to served fixtures. */
+export const paths: Record<string, string> = {
+	'/whatsapp': '/whatsapp',
+	'/whatsapp/': '/whatsapp',
+	'/whatsapp/conversations/$conversationId': `/whatsapp/conversations/${conversationID}`,
+}
+
+export { handlers }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved route coverage checks to automatically include standard and enterprise plugin routes.
  * Added parameterized rendering coverage for dynamically discovered plugin pages.
  * Simplified test setup by automatically registering available plugin handlers.

* **Bug Fixes**
  * Added route coverage for Fields, Importer, and WhatsApp plugin pages.
  * Improved consistency for WhatsApp conversation fixture routing and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->