### PR TITLE
Make the lint script run the eslint sweep CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm lint
       - run: pnpm lint:css
-      - run: pnpm exec eslint .
-        working-directory: ${{ github.workspace }}
       - run: pnpm cover
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
 		"build": "tsc -b && vite build",
 		"cover": "vitest run --coverage",
 		"dev": "vite",
-		"lint": "oxlint",
+		"lint": "oxlint && pnpm -w exec eslint .",
 		"lint:css": "stylelint \"src/**/*.css\"",
 		"preview": "vite preview",
 		"typecheck": "tsc -b"


### PR DESCRIPTION
The frontend lint script ran oxlint alone, while CI also ran eslint at the workspace root, where the jsdoc, tsdoc, sonarjs and complexity rules live. A clean local lint therefore proved less than a green CI, and a violation eslint refuses sailed through the local command twice during the last two cycles.

The script now runs oxlint and then the root eslint sweep, and CI drops its separate eslint step since the script carries it. CI and a developer now run the identical command, so the two cannot drift apart again.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend linting to run both Oxlint and ESLint across the project.
  * Streamlined frontend CI checks by removing a redundant standalone ESLint run.
  * Existing frontend validation steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->