### PR TITLE
Measure coverage over every workspace frontend

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 /// <reference types="vitest/config" />
+import { fileURLToPath } from 'node:url'
+
 import { godminDedupe, godminSingleCopy, godminStylesheetFirst } from '@gopherium/godmin/vite'
 import react from '@vitejs/plugin-react'
 import dsTokenFallbacks from '@wordpress/theme/vite-plugins/vite-ds-token-fallbacks'
 import { defineConfig } from 'vite'
+
+/** Resolves a repository path to the absolute glob coverage matching needs. */
+function repoGlob(pattern: string): string {
+	return fileURLToPath(new URL(`../${pattern}`, import.meta.url))
+}
 
 export default defineConfig({
 	plugins: [react(), dsTokenFallbacks(), godminSingleCopy(), godminStylesheetFirst()],
@@ -21,24 +28,26 @@ export default defineConfig({
 		},
 	},
 	test: {
+		root: repoGlob(''),
 		environment: 'jsdom',
 		env: { TZ: 'UTC' },
-		setupFiles: ['./src/test/setup.ts'],
+		setupFiles: [repoGlob('frontend/src/test/setup.ts')],
 		include: [
-			'src/**/*.test.{ts,tsx}',
-			'../sdk/*/test/*.test.{ts,tsx}',
-			'../plugins/*/frontend/test/*.test.{ts,tsx}',
-			'../enterprise/*/frontend/test/*.test.{ts,tsx}',
+			'frontend/src/**/*.test.{ts,tsx}',
+			'sdk/*/test/*.test.{ts,tsx}',
+			'plugins/*/frontend/test/*.test.{ts,tsx}',
+			'enterprise/*/frontend/test/*.test.{ts,tsx}',
 		],
 		coverage: {
 			include: [
-				'src/**',
-				'../sdk/*/**/*.{ts,tsx}',
-				'../plugins/*/frontend/**/*.{ts,tsx}',
-				'../enterprise/*/frontend/**/*.{ts,tsx}',
+				repoGlob('frontend/src/**'),
+				repoGlob('sdk/*/**/*.{ts,tsx}'),
+				repoGlob('plugins/*/frontend/**/*.{ts,tsx}'),
+				repoGlob('enterprise/*/frontend/**/*.{ts,tsx}'),
 			],
-			exclude: ['src/main.tsx', '**/gql/**', '**/test/**', '**/node_modules/**', '**/*.d.ts'],
+			exclude: ['frontend/src/main.tsx', '**/gql/**', '**/test/**', '**/node_modules/**', '**/*.d.ts'],
 			allowExternal: true,
+			reportsDirectory: repoGlob('frontend/coverage'),
 			reporter: ['text', 'lcov'],
 			thresholds: {
 				statements: 100,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,11 +6,11 @@ import { fileURLToPath } from 'node:url'
 import { godminDedupe, godminSingleCopy, godminStylesheetFirst } from '@gopherium/godmin/vite'
 import react from '@vitejs/plugin-react'
 import dsTokenFallbacks from '@wordpress/theme/vite-plugins/vite-ds-token-fallbacks'
-import { defineConfig } from 'vite'
+import { defineConfig, normalizePath } from 'vite'
 
 /** Resolves a repository path to the absolute glob coverage matching needs. */
 function repoGlob(pattern: string): string {
-	return fileURLToPath(new URL(`../${pattern}`, import.meta.url))
+	return normalizePath(fileURLToPath(new URL(`../${pattern}`, import.meta.url)))
 }
 
 export default defineConfig({


### PR DESCRIPTION
Closes #67

Three of the coverage include globs were written as upward relative paths, which vitest matches against absolute file paths, so they never matched anything. The 100 percent gate genuinely measured frontend/src alone. Worse, a file outside the vite root that no test imports failed the coverage transform with a parse error and was silently excluded, so even a working glob would not have caught an untested SDK file. And the lcov file CI uploads only ever carried frontend/src records, so the coverage service never saw the rest either.

One change closes all three. The test root moves to the repository root, which is what the suite actually spans, so the uncovered file transform finds every workspace file. The include globs resolve to absolute paths through a small helper, and the reports directory is pinned to frontend/coverage where CI already uploads from. The lcov records now carry repository relative paths for every measured file.

The thresholds still read 100 percent on all four counters, now over 83 files instead of the 39 the CI venue measured before.

## Testing

\`\`\`sh
pnpm install --frozen-lockfile
cd frontend && pnpm run cover
\`\`\`

Expect 430 tests and 100 percent on statements, branches, functions and lines. Then check the gate has teeth outside frontend/src, which it never had before:

1. Create sdk/frontend/probe.ts exporting a small function with a docblock, imported by nothing.
2. Rerun pnpm run cover. It reports probe.ts at 0 percent and all four thresholds fail. On main the same probe passes silently with a parse error buried in the output.
3. Delete the probe and rerun. Green again.

Finally confirm the upload artifact covers the workspace: grep -c '^SF:' frontend/coverage/lcov.info answers 83, and the paths inside are repository relative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test and coverage path resolution to use consistent repository-wide locations.
  * Ensured file paths are normalized correctly across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->