### PR TITLE
Refuse a role no plugin declares by its own name

### DIFF
--- a/cmd/alphone/createadmin_test.go
+++ b/cmd/alphone/createadmin_test.go
@@ -127,7 +127,7 @@ func TestCreateAdminRefusesARoleTheRegistryDoesNotKnow(t *testing.T) {
 	err := createAdmin(
 		t.Context(),
 		getenv,
-		[]string{"-email", "admin@example.com", "-name", "Admin", "-role", "superadmin"},
+		[]string{"-email", "admin@example.com", "-name", "Admin", "-role", "undeclared"},
 		strings.NewReader("correct horse battery\n"),
 		io.Discard,
 	)

--- a/cmd/alphone/grantrole_test.go
+++ b/cmd/alphone/grantrole_test.go
@@ -80,7 +80,7 @@ func TestGrantRoleRefusesARoleTheRegistryDoesNotKnow(t *testing.T) {
 
 	getenv := testGetenv(map[string]string{"ALPHONE_DATABASE_URL": testDatabaseURL(t)})
 
-	err := grantRole(t.Context(), getenv, []string{"-role", "superadmin"}, &strings.Builder{})
+	err := grantRole(t.Context(), getenv, []string{"-role", "undeclared"}, &strings.Builder{})
 
 	if !errors.Is(err, role.ErrUnknownTier) {
 		t.Errorf("grantRole() error = %v, want a role no plugin declared refused", err)


### PR DESCRIPTION
Closes #87

## What

The two role refusal tests pin `undeclared` as the role the registry cannot know, in place of `superadmin`.

## Why

`superadmin` is the name the roles cycle reserved for a plugin to declare. A tree carrying such a plugin makes the registry know it, so both tests went red while the code behaved exactly as intended. The name a refusal test pins has to be one nothing will ever claim.

## Testing Instructions

1. Run `go test ./cmd/alphone/ -run RefusesARoleTheRegistryDoesNotKnow` and see both tests pass.
2. Confirm the tests still fail for the right reason by changing `undeclared` to `admin` in either file and running the same command. Both should fail, since the registry does know `admin`. Restore the file afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unknown-role test coverage to use the `undeclared` role.
  * Confirmed unknown roles continue to return the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->