### PR TITLE
Answer and write only the caller's own tenant

### DIFF
--- a/internal/graphres/auth.go
+++ b/internal/graphres/auth.go
@@ -62,15 +62,29 @@ func (q QueryResolvers) Me(ctx context.Context) (*model.Identity, error) {
 	return toAuthIdentity(identity, role.Role(identity.Role)), nil
 }
 
-// Users lists every user account.
+// Users lists the accounts standing in the caller's tenant.
 func (q QueryResolvers) Users(ctx context.Context) ([]*model.User, error) {
 	accounts, err := q.root.Admin.ListAccounts(ctx)
 	if err != nil {
 		return nil, err
 	}
-	users := make([]*model.User, len(accounts))
-	for i, account := range accounts {
-		users[i] = toUser(account, role.Role(account.Role))
+	caller := authkit.IdentityFromContext(ctx).ID
+	ids := make([]uuid.UUID, 0, len(accounts)+1)
+	ids = append(ids, caller)
+	for _, account := range accounts {
+		ids = append(ids, account.ID)
+	}
+	placed, err := q.root.tenantsOf(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	standing := placedIn(placed, caller)
+	users := make([]*model.User, 0, len(accounts))
+	for _, account := range accounts {
+		if placedIn(placed, account.ID) != standing {
+			continue
+		}
+		users = append(users, toUser(account, role.Role(account.Role)))
 	}
 	return users, nil
 }

--- a/internal/graphres/graphres.go
+++ b/internal/graphres/graphres.go
@@ -56,6 +56,7 @@ type TaskStore interface {
 // TenantStore reads the tenant a caller stands in.
 type TenantStore interface {
 	TenantForUser(ctx context.Context, userID uuid.UUID) (tenant.Tenant, error)
+	TenantsOf(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]uuid.UUID, error)
 }
 
 // WebhookStore provides the webhook subscriptions the graph manages.
@@ -65,7 +66,7 @@ type WebhookStore interface {
 	DeleteSubscription(ctx context.Context, userID, id uuid.UUID) error
 }
 
-// outranking refuses an actor writing an account whose role holds a capability the actor lacks.
+// outranking refuses an actor writing an account of another tenant or holding a capability it lacks.
 func (r *Resolver) outranking(ctx context.Context, actor authkit.Identity, target uuid.UUID) error {
 	held, err := r.Admin.ListAccounts(ctx)
 	if err != nil {
@@ -75,12 +76,37 @@ func (r *Resolver) outranking(ctx context.Context, actor authkit.Identity, targe
 		if account.ID != target {
 			continue
 		}
+		placed, err := r.tenantsOf(ctx, []uuid.UUID{actor.ID, account.ID})
+		if err != nil {
+			return err
+		}
+		if placedIn(placed, actor.ID) != placedIn(placed, account.ID) {
+			return gouncer.ErrUserNotFound
+		}
 		if !role.Outranks(role.Role(actor.Role), role.Role(account.Role)) {
 			return role.ErrBeyondReach
 		}
 		return nil
 	}
 	return gouncer.ErrUserNotFound
+}
+
+// tenantsOf returns the tenant each named account a row places stands in, the rest absent.
+func (r *Resolver) tenantsOf(
+	ctx context.Context, ids []uuid.UUID,
+) (map[uuid.UUID]uuid.UUID, error) {
+	if r.Tenants == nil {
+		return nil, nil
+	}
+	return r.Tenants.TenantsOf(ctx, ids)
+}
+
+// placedIn returns the tenant a placement holds for one account, the default when none does.
+func placedIn(placed map[uuid.UUID]uuid.UUID, id uuid.UUID) uuid.UUID {
+	if standing, ok := placed[id]; ok {
+		return standing
+	}
+	return tenant.DefaultID
 }
 
 // TokenStore serves the caller's own API tokens.

--- a/internal/graphres/tenantboundary_test.go
+++ b/internal/graphres/tenantboundary_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package graphres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gopherium/gouncer/authkit"
+	"github.com/gopherium/gouncer/authkit/testkit"
+
+	"github.com/gopherium/alphone/internal/role"
+	"github.com/gopherium/alphone/internal/tenant"
+)
+
+// standingTenants places named users in a tenant, answering the default for the rest.
+type standingTenants struct {
+	standing map[uuid.UUID]uuid.UUID
+}
+
+// TenantForUser answers the tenant the user stands in.
+func (s standingTenants) TenantForUser(_ context.Context, userID uuid.UUID) (tenant.Tenant, error) {
+	held, ok := s.standing[userID]
+	if !ok {
+		held = tenant.DefaultID
+	}
+	return tenant.Tenant{ID: held, Name: "Standing"}, nil
+}
+
+// TenantsOf answers the tenant of every named user a row places.
+func (s standingTenants) TenantsOf(
+	_ context.Context, ids []uuid.UUID,
+) (map[uuid.UUID]uuid.UUID, error) {
+	held := make(map[uuid.UUID]uuid.UUID)
+	for _, id := range ids {
+		if placed, ok := s.standing[id]; ok {
+			held[id] = placed
+		}
+	}
+	return held, nil
+}
+
+// roledUser adds an account standing in a role to the store.
+func roledUser(t *testing.T, store *testkit.Store, email string, tier role.Role) uuid.UUID {
+	t.Helper()
+	held := store.AddUser(t, email, "Maria Perez", testPassword)
+	held.Role = tier.String()
+	store.Users[held.ID] = held
+	return held.ID
+}
+
+func TestUsersListsOnlyTheTenantTheCallerStandsIn(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	theirs := roledUser(t, store, "stranger@example.com", role.Admin)
+	acme, globex := uuid.New(), uuid.New()
+	resolver := newAuthResolver(store)
+	resolver.Tenants = standingTenants{
+		standing: map[uuid.UUID]uuid.UUID{mine: acme, theirs: globex},
+	}
+	client := newGraphClient(t, resolver, mine)
+
+	var listed struct {
+		Users []struct {
+			Email string `json:"email"`
+		} `json:"users"`
+	}
+	client.MustPost(`{ users { email } }`, &listed)
+
+	if len(listed.Users) != 1 {
+		t.Fatalf("users = %d accounts, want only the tenant the caller stands in", len(listed.Users))
+	}
+	if listed.Users[0].Email != "maria@example.com" {
+		t.Errorf("email = %q, want the caller's own account", listed.Users[0].Email)
+	}
+}
+
+func TestUsersListsTheDefaultTenantWhenNoRowPlacesAnAccount(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	unplaced := roledUser(t, store, "unplaced@example.com", role.Member)
+	theirs := roledUser(t, store, "stranger@example.com", role.Member)
+	resolver := newAuthResolver(store)
+	resolver.Tenants = standingTenants{standing: map[uuid.UUID]uuid.UUID{theirs: uuid.New()}}
+	client := newGraphClient(t, resolver, mine)
+
+	var listed struct {
+		Users []struct {
+			ID string `json:"id"`
+		} `json:"users"`
+	}
+	client.MustPost(`{ users { id } }`, &listed)
+
+	held := make(map[string]bool, len(listed.Users))
+	for _, listedUser := range listed.Users {
+		held[listedUser.ID] = true
+	}
+	if !held[mine.String()] || !held[unplaced.String()] {
+		t.Errorf("users = %v, want every account no row places read as the default tenant", held)
+	}
+	if held[theirs.String()] {
+		t.Error("users carried another tenant's account, want it withheld")
+	}
+}
+
+func TestSetUserDisabledRefusesAnAccountOfAnotherTenant(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	theirs := roledUser(t, store, "stranger@example.com", role.Admin)
+	resolver := newAuthResolver(store)
+	resolver.Tenants = standingTenants{
+		standing: map[uuid.UUID]uuid.UUID{mine: uuid.New(), theirs: uuid.New()},
+	}
+	actor := authkit.Identity{ID: mine, Role: role.Admin.String()}
+	client := newActingClient(t, resolver, actor)
+
+	answered, err := client.RawPost(settingDisabled(theirs, true))
+
+	if err != nil {
+		t.Fatalf("RawPost() error = %v, want nil", err)
+	}
+	if len(answered.Errors) == 0 {
+		t.Error("setUserDisabled answered no error, want an account of another tenant refused")
+	}
+	if store.Users[theirs].Disabled {
+		t.Error("stored account is disabled, want the refused write to leave it")
+	}
+}
+
+func TestUsersReportsATenantStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	resolver := newAuthResolver(store)
+	resolver.Tenants = failingTenantStore{}
+	client := newGraphClient(t, resolver, mine)
+
+	answered, err := client.RawPost(`{ users { id } }`)
+
+	if err != nil {
+		t.Fatalf("RawPost() error = %v, want nil", err)
+	}
+	if len(answered.Errors) == 0 {
+		t.Error("users answered no error, want the tenant store failure reported")
+	}
+}
+
+func TestSetUserDisabledReportsATenantStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	target := roledUser(t, store, "colleague@example.com", role.Admin)
+	resolver := newAuthResolver(store)
+	resolver.Tenants = failingTenantStore{}
+	actor := authkit.Identity{ID: mine, Role: role.Admin.String()}
+	client := newActingClient(t, resolver, actor)
+
+	answered, err := client.RawPost(settingDisabled(target, true))
+
+	if err != nil {
+		t.Fatalf("RawPost() error = %v, want nil", err)
+	}
+	if len(answered.Errors) == 0 {
+		t.Error("setUserDisabled answered no error, want the tenant store failure reported")
+	}
+}
+
+func TestUsersListsEveryAccountWhereNoTenantStoreAnswers(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	roledUser(t, store, "colleague@example.com", role.Member)
+	resolver := newAuthResolver(store)
+	client := newGraphClient(t, resolver, mine)
+
+	var listed struct {
+		Users []struct {
+			ID string `json:"id"`
+		} `json:"users"`
+	}
+	client.MustPost(`{ users { id } }`, &listed)
+
+	if len(listed.Users) != 2 {
+		t.Errorf("users = %d accounts, want every account of a single tenant install", len(listed.Users))
+	}
+}
+
+func TestSetUserDisabledAdmitsAnAccountOfTheCallersOwnTenant(t *testing.T) {
+	t.Parallel()
+
+	store := testkit.NewStore()
+	mine := roledUser(t, store, "maria@example.com", role.Admin)
+	colleague := roledUser(t, store, "colleague@example.com", role.Admin)
+	acme := uuid.New()
+	resolver := newAuthResolver(store)
+	resolver.Tenants = standingTenants{
+		standing: map[uuid.UUID]uuid.UUID{mine: acme, colleague: acme},
+	}
+	actor := authkit.Identity{ID: mine, Role: role.Admin.String()}
+	client := newActingClient(t, resolver, actor)
+
+	answered, err := client.RawPost(settingDisabled(colleague, true))
+
+	if err != nil {
+		t.Fatalf("RawPost() error = %v, want nil", err)
+	}
+	if len(answered.Errors) != 0 {
+		t.Errorf("setUserDisabled answered %v, want a tenant managing its own accounts", answered.Errors)
+	}
+	if !store.Users[colleague].Disabled {
+		t.Error("stored account is enabled, want the write to land inside the tenant")
+	}
+}

--- a/internal/graphres/tenants_test.go
+++ b/internal/graphres/tenants_test.go
@@ -24,6 +24,13 @@ func (failingTenantStore) TenantForUser(context.Context, uuid.UUID) (tenant.Tena
 	return tenant.Tenant{}, errTenantStore
 }
 
+// TenantsOf reports the store failure.
+func (failingTenantStore) TenantsOf(
+	context.Context, []uuid.UUID,
+) (map[uuid.UUID]uuid.UUID, error) {
+	return nil, errTenantStore
+}
+
 // tenantRead is the answer shape of the tenant query.
 type tenantRead struct {
 	Tenant struct {

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -901,6 +901,37 @@ func (q *Queries) TenantForUser(ctx context.Context, arg TenantForUserParams) (T
 	return i, err
 }
 
+const tenantsOfUsers = `-- name: TenantsOfUsers :many
+SELECT user_id, tenant_id
+FROM core.tenant_members
+WHERE user_id = ANY($1::uuid[])
+`
+
+type TenantsOfUsersRow struct {
+	UserID   uuid.UUID
+	TenantID uuid.UUID
+}
+
+func (q *Queries) TenantsOfUsers(ctx context.Context, ids []uuid.UUID) ([]TenantsOfUsersRow, error) {
+	rows, err := q.db.Query(ctx, tenantsOfUsers, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TenantsOfUsersRow
+	for rows.Next() {
+		var i TenantsOfUsersRow
+		if err := rows.Scan(&i.UserID, &i.TenantID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const touchAPIToken = `-- name: TouchAPIToken :exec
 UPDATE core.api_tokens
 SET last_used_at = $2

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -199,6 +199,11 @@ WHERE m.user_id IS NOT NULL OR t.id = @default_id::uuid
 ORDER BY m.user_id IS NOT NULL DESC
 LIMIT 1;
 
+-- name: TenantsOfUsers :many
+SELECT user_id, tenant_id
+FROM core.tenant_members
+WHERE user_id = ANY(@ids::uuid[]);
+
 -- name: UserSetting :many
 SELECT value
 FROM core.user_settings

--- a/internal/postgres/tenants.go
+++ b/internal/postgres/tenants.go
@@ -23,6 +23,21 @@ func NewTenantStore(pool *pgxpool.Pool) *TenantStore {
 	return &TenantStore{queries: db.New(pool)}
 }
 
+// TenantsOf returns the tenant of every named user a row places, the rest absent.
+func (s *TenantStore) TenantsOf(
+	ctx context.Context, ids []uuid.UUID,
+) (map[uuid.UUID]uuid.UUID, error) {
+	rows, err := s.queries.TenantsOfUsers(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("read tenants: %w", err)
+	}
+	placed := make(map[uuid.UUID]uuid.UUID, len(rows))
+	for _, row := range rows {
+		placed[row.UserID] = row.TenantID
+	}
+	return placed, nil
+}
+
 // TenantForUser returns the user's tenant, the default when no row places them.
 func (s *TenantStore) TenantForUser(ctx context.Context, userID uuid.UUID) (tenant.Tenant, error) {
 	row, err := s.queries.TenantForUser(ctx, db.TenantForUserParams{

--- a/internal/postgres/tenants_test.go
+++ b/internal/postgres/tenants_test.go
@@ -63,6 +63,48 @@ func TestTenantForUserAnswersThePlacedTenant(t *testing.T) {
 	}
 }
 
+func TestTenantsOfAnswersOnlyTheUsersARowPlaces(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	store := postgres.NewTenantStore(pool)
+	acme := uuid.Must(uuid.NewV7())
+	member := uuid.Must(uuid.NewV7())
+	unplaced := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenant_members (user_id, tenant_id) VALUES ($1, $2)", member, acme); err != nil {
+		t.Fatalf("placing the member: %v", err)
+	}
+
+	placed, err := store.TenantsOf(t.Context(), []uuid.UUID{member, unplaced})
+
+	if err != nil {
+		t.Fatalf("TenantsOf() error = %v, want nil", err)
+	}
+	if placed[member] != acme {
+		t.Errorf("placed[member] = %v, want %v", placed[member], acme)
+	}
+	if _, held := placed[unplaced]; held {
+		t.Error("placed carried the unplaced account, want absence answering the default")
+	}
+}
+
+func TestTenantsOfReportsAStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	store := postgres.NewTenantStore(pool)
+	pool.Close()
+
+	if _, err := store.TenantsOf(t.Context(), []uuid.UUID{uuid.Must(uuid.NewV7())}); err == nil {
+		t.Error("TenantsOf() error = nil, want the closed pool reported")
+	}
+}
+
 func TestMigrationSeedsTheDefaultTenantExactlyOnce(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #89

## What

`Query.users` answers only the accounts standing in the caller's tenant, and an account of another tenant can no longer be disabled or have its role changed. Absence of a membership row still reads as the default tenant, so a single tenant install lists and manages every account exactly as before.

## Why

Both paths were correct for one customer and leaked for two. The listing carried no boundary at all, so an admin would have read every other customer's staff and their addresses. The write guard checked only whether the caller's role reached the target's, never whether the two stood in the same tenant.

The admin cover count in the auth brick is still install wide, which is imprecise but not reachable: self disable and self role change are both refused, and a peer admin demoting another still leaves the acting admin standing, so no path removes a tenant's last admin once cross tenant writes are refused. Fixing it would mean a brick release for no reachable gain.

## Testing Instructions

1. Run `make seed && make dev`, then log in as admin@example.com with the password password1234.
2. Open Users and confirm every seeded account is listed, since no row places them and they all read as the default tenant.
3. Place one account in another tenant by hand: `docker compose exec postgres psql -U postgres -d postgres -c "INSERT INTO core.tenants (id, name) VALUES ('00000000-0000-7000-8000-0000000000ff', 'Acme'); INSERT INTO core.tenant_members (user_id, tenant_id) SELECT id, '00000000-0000-7000-8000-0000000000ff' FROM auth.users WHERE email = 'maria@example.com';"`
4. Reload Users. That account is gone from the list, and the others remain.
5. Confirm the write boundary by asking the graph to disable it directly, using its id from the query above. The mutation refuses rather than disabling.
6. Remove the placement to restore the install: `docker compose exec postgres psql -U postgres -d postgres -c "DELETE FROM core.tenant_members; DELETE FROM core.tenants WHERE name = 'Acme';"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User listings are now limited to accounts within the caller’s tenant.
  - Accounts without an assigned tenant use the default tenant.

- **Bug Fixes**
  - Prevented account administration actions across tenant boundaries.
  - Tenant lookup and database errors are now surfaced correctly.

- **Tests**
  - Added coverage for tenant-scoped listings, cross-tenant restrictions, default-tenant behavior, successful same-tenant actions, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->