### PR TITLE
Every test helper says what it is for

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,32 @@
+reviews:
+  path_instructions:
+    - path: "**/*.go"
+      instructions: >-
+        The only comment this repository allows is a docblock directly above a declaration. A
+        docblock starts with the name of what it documents, and states WHAT
+        that thing does and never how or why. Do not ask for inline comments, TODO markers,
+        or section markers.
+    - path: "**/*_test.go"
+      instructions: >-
+        Test functions here deliberately carry no doc comment. Their name states what they verify
+        and every one of them follows that convention, so never ask for a doc comment on a
+        function whose name begins with Test, Benchmark or Fuzz. Helper functions and methods in
+        test files do carry a one line docblock, so a missing one there is worth reporting.
+    - path: "**/*.sql"
+      instructions: >-
+        Migrations carry no comments of any kind, so never ask for one to be added. A down
+        migration that refuses to run while data violates the constraint it restores is behaving
+        correctly, because the alternative is destroying rows to satisfy a rollback.
+    - path: "**/languages/*.po"
+      instructions: >-
+        Machine written translations are committed flagged fuzzy on purpose and they ship that way
+        in the runtime catalogues, which is a deliberate departure from gettext dropping fuzzy
+        entries at compile time. Translators clear the flag after review, so never ask for a fuzzy
+        entry to be removed, emptied or withheld from the build.
+code_generation:
+  docstrings:
+    path_instructions:
+      - path: "**/*_test.go"
+        instructions: >-
+          Never generate a docstring for a function whose name begins with Test, Benchmark or
+          Fuzz. Helpers take a single line starting with the function name.

--- a/cmd/alphone/main_exec_test.go
+++ b/cmd/alphone/main_exec_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gopherium/alphone/internal/version"
 )
 
+// coverBinary returns the path of the alphone cover binary and the environment to run it with.
 func coverBinary(t *testing.T) (string, []string) {
 	t.Helper()
 	bindir := os.Getenv("ALPHONE_COVER_BINDIR")

--- a/cmd/alphone/main_test.go
+++ b/cmd/alphone/main_test.go
@@ -119,32 +119,39 @@ var errPluginMigrate = errors.New("plugin migration exploded")
 
 type failingPlugin struct{}
 
+// ID returns the plugin's identifier.
 func (failingPlugin) ID() string {
 	return "failing"
 }
 
+// Start returns nil without starting anything.
 func (failingPlugin) Start(_ context.Context) error {
 	return nil
 }
 
+// Stop returns nil without stopping anything.
 func (failingPlugin) Stop(_ context.Context) error {
 	return nil
 }
 
+// Migrate returns the plugin migration failure.
 func (failingPlugin) Migrate(_ context.Context) error {
 	return errPluginMigrate
 }
 
+// failingPlugins returns one plugin whose migration always fails.
 func failingPlugins(_ sdk.Deps) ([]sdk.Plugin, error) {
 	return []sdk.Plugin{failingPlugin{}}, nil
 }
 
+// testGetenv returns an environment lookup answering from the given values.
 func testGetenv(values map[string]string) func(string) string {
 	return func(key string) string {
 		return values[key]
 	}
 }
 
+// newContactStore returns a contact store over a pool on a fresh test database.
 func newContactStore(t *testing.T) *postgres.ContactStore {
 	t.Helper()
 	pool, err := pgxpool.New(t.Context(), testDatabaseURL(t))
@@ -155,6 +162,7 @@ func newContactStore(t *testing.T) *postgres.ContactStore {
 	return postgres.NewContactStore(pool)
 }
 
+// testDatabaseURL returns the URL of a fresh migrated database, skipping the test in short mode.
 func testDatabaseURL(t *testing.T) string {
 	t.Helper()
 	if testing.Short() {
@@ -164,6 +172,7 @@ func testDatabaseURL(t *testing.T) string {
 	return cfg.URL()
 }
 
+// freeAddr returns a localhost address that is free to bind.
 func freeAddr(t *testing.T) string {
 	t.Helper()
 	listener, err := net.Listen("tcp", "localhost:0")
@@ -177,6 +186,7 @@ func freeAddr(t *testing.T) string {
 	return addr
 }
 
+// waitForServer waits until the server at baseURL answers the version probe.
 func waitForServer(t *testing.T, baseURL string) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -465,6 +475,7 @@ func postGraphAuthed(
 	return string(answer)
 }
 
+// doAuthed sends a JSON request carrying the session cookie and returns the answer.
 func doAuthed(
 	t *testing.T,
 	ctx context.Context,

--- a/cmd/alphone/plugins_test.go
+++ b/cmd/alphone/plugins_test.go
@@ -18,18 +18,22 @@ var errStore = errors.New("the contact store is unreachable")
 // failingStore answers every contact read and write with errStore.
 type failingStore struct{}
 
+// Get returns an empty contact and errStore.
 func (failingStore) Get(context.Context, uuid.UUID) (contact.Contact, error) {
 	return contact.Contact{}, errStore
 }
 
+// LookupIdentity returns an empty identity and errStore.
 func (failingStore) LookupIdentity(context.Context, contact.Channel, string) (contact.Identity, error) {
 	return contact.Identity{}, errStore
 }
 
+// CreateContactWithIdentity returns errStore.
 func (failingStore) CreateContactWithIdentity(context.Context, contact.Contact, contact.Identity) error {
 	return errStore
 }
 
+// CreateContactWithIdentities returns errStore.
 func (failingStore) CreateContactWithIdentities(context.Context, contact.Contact, []contact.Identity) error {
 	return errStore
 }

--- a/cmd/alphone/seed_test.go
+++ b/cmd/alphone/seed_test.go
@@ -25,10 +25,12 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read returns the entropy failure instead of any bytes.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }
 
+// testPool returns a pool on the given database URL, closed when the test ends.
 func testPool(t *testing.T, databaseURL string) *pgxpool.Pool {
 	t.Helper()
 	pool, err := pgxpool.New(t.Context(), databaseURL)
@@ -39,6 +41,7 @@ func testPool(t *testing.T, databaseURL string) *pgxpool.Pool {
 	return pool
 }
 
+// countRows returns the number of rows in the named table.
 func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
 	t.Helper()
 	var count int
@@ -48,6 +51,7 @@ func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
 	return count
 }
 
+// demoCounts returns the row counts of the seven tables the demo data fills.
 func demoCounts(t *testing.T, pool *pgxpool.Pool) [7]int {
 	t.Helper()
 	return [7]int{

--- a/cmd/doclint/doclint_test.go
+++ b/cmd/doclint/doclint_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 )
 
+// write creates the named file under the directory with the given body.
 func write(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {

--- a/cmd/doclint/main_exec_test.go
+++ b/cmd/doclint/main_exec_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 )
 
+// coverBinary returns the built doclint path and a coverage environment, skipping the test outside make cover.
 func coverBinary(t *testing.T) (string, []string) {
 	t.Helper()
 	bindir := os.Getenv("ALPHONE_COVER_BINDIR")
@@ -28,6 +29,7 @@ func coverBinary(t *testing.T) (string, []string) {
 	return filepath.Join(bindir, "doclint"), append(env, "GOCOVERDIR="+gocoverdir)
 }
 
+// writeFixture writes one source file into the given directory.
 func writeFixture(t *testing.T, dir, name, source string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(source), 0o644); err != nil {

--- a/cmd/pluginwire/main_exec_test.go
+++ b/cmd/pluginwire/main_exec_test.go
@@ -42,6 +42,7 @@ func writeTree(t *testing.T, root string) {
 	}
 }
 
+// coverBinary returns the coverage built pluginwire path and its environment, skipping the test when unset.
 func coverBinary(t *testing.T) (string, []string) {
 	t.Helper()
 	bindir := os.Getenv("ALPHONE_COVER_BINDIR")

--- a/cmd/schemagen/main_exec_test.go
+++ b/cmd/schemagen/main_exec_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 )
 
+// coverBinary returns the path of the schemagen cover binary and the environment to run it with.
 func coverBinary(t *testing.T) (string, []string) {
 	t.Helper()
 	bindir := os.Getenv("ALPHONE_COVER_BINDIR")

--- a/internal/apitoken/apitoken_internal_test.go
+++ b/internal/apitoken/apitoken_internal_test.go
@@ -13,6 +13,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read returns an entropy failure instead of random bytes.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/internal/contact/contact_test.go
+++ b/internal/contact/contact_test.go
@@ -16,6 +16,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read reads no bytes and reports the entropy failure.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/internal/contact/resolver_test.go
+++ b/internal/contact/resolver_test.go
@@ -29,6 +29,7 @@ type fakeStore struct {
 	beforeCreate func()
 }
 
+// newFakeStore returns an empty in memory contact store.
 func newFakeStore() *fakeStore {
 	return &fakeStore{
 		contacts:   map[uuid.UUID]contact.Contact{},
@@ -36,6 +37,7 @@ func newFakeStore() *fakeStore {
 	}
 }
 
+// Get returns the stored contact the id names, or the configured failure.
 func (f *fakeStore) Get(_ context.Context, id uuid.UUID) (contact.Contact, error) {
 	if f.getErr != nil {
 		return contact.Contact{}, f.getErr
@@ -47,6 +49,7 @@ func (f *fakeStore) Get(_ context.Context, id uuid.UUID) (contact.Contact, error
 	return c, nil
 }
 
+// LookupIdentity returns the stored identity for the channel and identifier, or the configured failure.
 func (f *fakeStore) LookupIdentity(
 	_ context.Context,
 	channel contact.Channel,
@@ -62,6 +65,7 @@ func (f *fakeStore) LookupIdentity(
 	return identity, nil
 }
 
+// CreateContactWithIdentity stores one contact and one identity, refusing an identifier already claimed.
 func (f *fakeStore) CreateContactWithIdentity(_ context.Context, c contact.Contact, identity contact.Identity) error {
 	if f.beforeCreate != nil {
 		f.beforeCreate()
@@ -78,6 +82,7 @@ func (f *fakeStore) CreateContactWithIdentity(_ context.Context, c contact.Conta
 	return nil
 }
 
+// CreateContactWithIdentities stores one contact and every given identity, refusing any identifier already claimed.
 func (f *fakeStore) CreateContactWithIdentities(
 	_ context.Context, c contact.Contact, identities []contact.Identity,
 ) error {
@@ -97,6 +102,7 @@ func (f *fakeStore) CreateContactWithIdentities(
 	return nil
 }
 
+// seedContact stores a named contact with one channel identity and returns it.
 func seedContact(
 	t *testing.T,
 	store *fakeStore,
@@ -311,6 +317,7 @@ type flakyReader struct {
 	allowed int
 }
 
+// Read fills the buffer for the allowed number of calls and then fails.
 func (r *flakyReader) Read(p []byte) (int, error) {
 	if r.allowed == 0 {
 		return 0, errEntropy
@@ -327,6 +334,7 @@ type recordingEvents struct {
 	data  []map[string]any
 }
 
+// Publish keeps the name and data of every published frame.
 func (r *recordingEvents) Publish(_ context.Context, frame event.Frame, data map[string]any) {
 	r.names = append(r.names, frame.Name)
 	r.data = append(r.data, data)

--- a/internal/event/event_internal_test.go
+++ b/internal/event/event_internal_test.go
@@ -13,6 +13,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read reads no bytes and returns the entropy failure.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/internal/graphres/auth_test.go
+++ b/internal/graphres/auth_test.go
@@ -232,10 +232,12 @@ type stubLimiter struct {
 	recordErr error
 }
 
+// Check allows the attempt and returns the configured check error.
 func (s stubLimiter) Check(string) (bool, time.Duration, error) {
 	return true, 0, s.checkErr
 }
 
+// RecordFailure returns the configured record error.
 func (s stubLimiter) RecordFailure(string) error {
 	return s.recordErr
 }

--- a/internal/graphres/branches_test.go
+++ b/internal/graphres/branches_test.go
@@ -393,14 +393,17 @@ type failingWebhookStore struct {
 	err error
 }
 
+// CreateSubscription returns the store's error instead of writing the subscription.
 func (s failingWebhookStore) CreateSubscription(context.Context, webhook.Subscription) error {
 	return s.err
 }
 
+// ListSubscriptionsForUser returns the store's error instead of any subscription.
 func (s failingWebhookStore) ListSubscriptionsForUser(context.Context, uuid.UUID) ([]webhook.Subscription, error) {
 	return nil, s.err
 }
 
+// DeleteSubscription returns the store's error instead of deleting the subscription.
 func (s failingWebhookStore) DeleteSubscription(context.Context, uuid.UUID, uuid.UUID) error {
 	return s.err
 }

--- a/internal/graphres/graph_test.go
+++ b/internal/graphres/graph_test.go
@@ -446,6 +446,7 @@ type stubContactStore struct {
 	addIdentityErr error
 }
 
+// Get returns the fixed contact the id names, or a not found error.
 func (s *stubContactStore) Get(_ context.Context, id uuid.UUID) (contact.Contact, error) {
 	c, ok := s.contacts[id]
 	if !ok {
@@ -454,6 +455,7 @@ func (s *stubContactStore) Get(_ context.Context, id uuid.UUID) (contact.Contact
 	return c, nil
 }
 
+// ListContacts returns the configured list error, or no contacts at all.
 func (s *stubContactStore) ListContacts(
 	_ context.Context, _, _, _ string, _ uuid.UUID, _ int,
 ) ([]contact.Contact, error) {
@@ -463,6 +465,7 @@ func (s *stubContactStore) ListContacts(
 	return nil, nil
 }
 
+// ListContactIdentities returns the configured identities error, or no identities at all.
 func (s *stubContactStore) ListContactIdentities(_ context.Context, _ uuid.UUID) ([]contact.Identity, error) {
 	if s.identitiesErr != nil {
 		return nil, s.identitiesErr
@@ -470,6 +473,7 @@ func (s *stubContactStore) ListContactIdentities(_ context.Context, _ uuid.UUID)
 	return nil, nil
 }
 
+// ListByIDs records the batch and returns the known contacts among the ids.
 func (s *stubContactStore) ListByIDs(_ context.Context, ids []uuid.UUID) ([]contact.Contact, error) {
 	if s.listByIDsErr != nil {
 		return nil, s.listByIDsErr
@@ -484,24 +488,29 @@ func (s *stubContactStore) ListByIDs(_ context.Context, ids []uuid.UUID) ([]cont
 	return found, nil
 }
 
+// Create accepts the contact and stores nothing.
 func (s *stubContactStore) Create(_ context.Context, _ contact.Contact) error {
 	return nil
 }
 
+// CreateContactWithIdentities accepts the contact and its identities and stores nothing.
 func (s *stubContactStore) CreateContactWithIdentities(
 	_ context.Context, _ contact.Contact, _ []contact.Identity,
 ) error {
 	return nil
 }
 
+// RenameContact always reports the contact as not found.
 func (s *stubContactStore) RenameContact(_ context.Context, _ uuid.UUID, _ string) (contact.Contact, error) {
 	return contact.Contact{}, contact.ErrNotFound
 }
 
+// AddIdentity returns the configured add identity error.
 func (s *stubContactStore) AddIdentity(_ context.Context, _ contact.Identity) error {
 	return s.addIdentityErr
 }
 
+// DeleteIdentity accepts the deletion and changes nothing.
 func (s *stubContactStore) DeleteIdentity(_ context.Context, _, _ uuid.UUID) error {
 	return nil
 }
@@ -514,6 +523,7 @@ type stubTaskStore struct {
 	listForContactErr error
 }
 
+// Get returns the fixed task the id names, or a not found error.
 func (s *stubTaskStore) Get(_ context.Context, id uuid.UUID) (task.Task, error) {
 	for _, stored := range s.tasks {
 		if stored.ID == id {
@@ -523,18 +533,21 @@ func (s *stubTaskStore) Get(_ context.Context, id uuid.UUID) (task.Task, error) 
 	return task.Task{}, task.ErrNotFound
 }
 
+// ListForDay returns the whole fixed task list for any day.
 func (s *stubTaskStore) ListForDay(
 	_ context.Context, _ uuid.UUID, _ time.Time, _ string, _ task.Page,
 ) ([]task.Task, error) {
 	return s.tasks, nil
 }
 
+// ListDueBefore returns no tasks at all.
 func (s *stubTaskStore) ListDueBefore(
 	_ context.Context, _ uuid.UUID, _ time.Time, _ string, _ task.Page,
 ) ([]task.Task, error) {
 	return nil, nil
 }
 
+// ListForContact returns the configured contact listing error, or no tasks at all.
 func (s *stubTaskStore) ListForContact(
 	_ context.Context, _ uuid.UUID, _ string, _ task.Page,
 ) ([]task.Task, error) {
@@ -544,6 +557,7 @@ func (s *stubTaskStore) ListForContact(
 	return nil, nil
 }
 
+// Create returns the configured create error, or the given task marked new.
 func (s *stubTaskStore) Create(_ context.Context, t task.Task) (task.Task, bool, error) {
 	if s.createErr != nil {
 		return task.Task{}, false, s.createErr
@@ -551,6 +565,7 @@ func (s *stubTaskStore) Create(_ context.Context, t task.Task) (task.Task, bool,
 	return t, true, nil
 }
 
+// Update returns the configured update error, or the given task unchanged.
 func (s *stubTaskStore) Update(_ context.Context, t task.Task) (task.Task, error) {
 	if s.updateErr != nil {
 		return task.Task{}, s.updateErr

--- a/internal/postgres/contacts_test.go
+++ b/internal/postgres/contacts_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gopherium/alphone/internal/testdb"
 )
 
+// newTestPool returns a connection pool over a fresh migrated test database, skipping in short mode.
 func newTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	if testing.Short() {

--- a/internal/postgres/postgres_test.go
+++ b/internal/postgres/postgres_test.go
@@ -21,6 +21,7 @@ const (
 	foreignKeyViolation = "23503"
 )
 
+// newTestDB returns a migrated throwaway database, skipping the test in short mode.
 func newTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	if testing.Short() {
@@ -29,6 +30,7 @@ func newTestDB(t *testing.T) *sql.DB {
 	return pgtestdb.New(t, testdb.Config(), testdb.Migrator())
 }
 
+// mustContact returns a new contact with the given name, failing the test on any error.
 func mustContact(t *testing.T, name string) contact.Contact {
 	t.Helper()
 	c, err := contact.New(name)
@@ -38,6 +40,7 @@ func mustContact(t *testing.T, name string) contact.Contact {
 	return c
 }
 
+// mustIdentity returns a new identity for the given contact, failing the test on any error.
 func mustIdentity(t *testing.T, contactID uuid.UUID, channel contact.Channel, identifier string) contact.Identity {
 	t.Helper()
 	identity, err := contact.NewIdentity(contactID, channel, identifier, "")
@@ -47,6 +50,7 @@ func mustIdentity(t *testing.T, contactID uuid.UUID, channel contact.Channel, id
 	return identity
 }
 
+// insertContact stores the contact row, failing the test on any error.
 func insertContact(t *testing.T, db *sql.DB, c contact.Contact) {
 	t.Helper()
 	_, err := db.Exec(
@@ -58,6 +62,7 @@ func insertContact(t *testing.T, db *sql.DB, c contact.Contact) {
 	}
 }
 
+// insertIdentity stores the identity row and returns the database error.
 func insertIdentity(db *sql.DB, identity contact.Identity) error {
 	_, err := db.Exec(
 		"INSERT INTO core.contact_identities "+

--- a/internal/postgres/tasklist_test.go
+++ b/internal/postgres/tasklist_test.go
@@ -16,6 +16,7 @@ import (
 
 var taskDay = time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC)
 
+// storeTask stores one task built from the input and returns it.
 func storeTask(t *testing.T, store *postgres.TaskStore, in task.Input) task.Task {
 	t.Helper()
 	created := mustTask(t, in)
@@ -25,6 +26,7 @@ func storeTask(t *testing.T, store *postgres.TaskStore, in task.Input) task.Task
 	return created
 }
 
+// completed sets the stored status of the named task to done.
 func completed(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) {
 	t.Helper()
 	if _, err := pool.Exec(t.Context(),
@@ -33,6 +35,7 @@ func completed(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) {
 	}
 }
 
+// titlesOf returns the titles of the given tasks in order.
 func titlesOf(tasks []task.Task) []string {
 	titles := make([]string, len(tasks))
 	for i, listed := range tasks {

--- a/internal/postgres/tasks_test.go
+++ b/internal/postgres/tasks_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gopherium/alphone/internal/task"
 )
 
+// mustTask returns a new task built from the input, failing the test if it is invalid.
 func mustTask(t *testing.T, in task.Input) task.Task {
 	t.Helper()
 	created, err := task.New(in)

--- a/internal/postgres/tokens_test.go
+++ b/internal/postgres/tokens_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gopherium/alphone/internal/testdb"
 )
 
+// mustMint returns a token minted for the user with full scopes and no expiry.
 func mustMint(t *testing.T, userID uuid.UUID, name string) apitoken.Minted {
 	t.Helper()
 	return mustMintScoped(t, userID, name, apitoken.Full(), apitoken.Never)

--- a/internal/postgres/webhooks_test.go
+++ b/internal/postgres/webhooks_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gopherium/alphone/internal/webhook"
 )
 
+// mustSubscription returns a subscription for the owner, url and event names, failing the test on error.
 func mustSubscription(t *testing.T, owner uuid.UUID, url string, events ...event.Name) webhook.Subscription {
 	t.Helper()
 	sub, err := webhook.NewSubscription(owner, url, events)
@@ -25,6 +26,7 @@ func mustSubscription(t *testing.T, owner uuid.UUID, url string, events ...event
 	return sub
 }
 
+// mustDelivery returns a delivery of a fresh task created event for the subscription, failing the test on error.
 func mustDelivery(t *testing.T, sub webhook.Subscription) webhook.Delivery {
 	t.Helper()
 	occurred, err := event.New(event.TaskCreated, map[string]any{"id": uuid.Must(uuid.NewV7()).String()})

--- a/internal/server/fakes_test.go
+++ b/internal/server/fakes_test.go
@@ -28,6 +28,7 @@ type fakeContactStore struct {
 	identities map[uuid.UUID][]contact.Identity
 }
 
+// newFakeContactStore returns an empty in memory contact store.
 func newFakeContactStore() *fakeContactStore {
 	return &fakeContactStore{
 		contacts:   map[uuid.UUID]contact.Contact{},
@@ -35,12 +36,14 @@ func newFakeContactStore() *fakeContactStore {
 	}
 }
 
+// ListContactIdentities returns the identities stored under the named contact.
 func (f *fakeContactStore) ListContactIdentities(
 	_ context.Context, contactID uuid.UUID,
 ) ([]contact.Identity, error) {
 	return f.identities[contactID], nil
 }
 
+// ListByIDs returns the stored contacts the given identifiers name.
 func (f *fakeContactStore) ListByIDs(_ context.Context, ids []uuid.UUID) ([]contact.Contact, error) {
 	var found []contact.Contact
 	for _, id := range ids {
@@ -51,6 +54,7 @@ func (f *fakeContactStore) ListByIDs(_ context.Context, ids []uuid.UUID) ([]cont
 	return found, nil
 }
 
+// identityOwner returns the contact holding the given channel identity and whether one holds it.
 func (f *fakeContactStore) identityOwner(channel contact.Channel, identifier string) (uuid.UUID, bool) {
 	for ownerID, identities := range f.identities {
 		for _, identity := range identities {
@@ -62,6 +66,7 @@ func (f *fakeContactStore) identityOwner(channel contact.Channel, identifier str
 	return uuid.Nil, false
 }
 
+// AddIdentity stores one identity under an existing contact and refuses an identity another contact holds.
 func (f *fakeContactStore) AddIdentity(_ context.Context, identity contact.Identity) error {
 	if _, ok := f.contacts[identity.ContactID]; !ok {
 		return contact.ErrNotFound
@@ -73,6 +78,7 @@ func (f *fakeContactStore) AddIdentity(_ context.Context, identity contact.Ident
 	return nil
 }
 
+// DeleteIdentity removes the named identity from the named contact.
 func (f *fakeContactStore) DeleteIdentity(_ context.Context, contactID, identityID uuid.UUID) error {
 	for i, identity := range f.identities[contactID] {
 		if identity.ID == identityID {
@@ -85,6 +91,7 @@ func (f *fakeContactStore) DeleteIdentity(_ context.Context, contactID, identity
 	return contact.ErrIdentityNotFound
 }
 
+// CreateContactWithIdentities stores one contact with its identities and refuses an identity already held.
 func (f *fakeContactStore) CreateContactWithIdentities(
 	_ context.Context, c contact.Contact, identities []contact.Identity,
 ) error {
@@ -98,6 +105,7 @@ func (f *fakeContactStore) CreateContactWithIdentities(
 	return nil
 }
 
+// RenameContact gives the named contact a new name and returns it.
 func (f *fakeContactStore) RenameContact(
 	_ context.Context, id uuid.UUID, name string,
 ) (contact.Contact, error) {
@@ -110,11 +118,13 @@ func (f *fakeContactStore) RenameContact(
 	return c, nil
 }
 
+// Create stores one contact.
 func (f *fakeContactStore) Create(_ context.Context, c contact.Contact) error {
 	f.contacts[c.ID] = c
 	return nil
 }
 
+// Get returns the stored contact the identifier names.
 func (f *fakeContactStore) Get(_ context.Context, id uuid.UUID) (contact.Contact, error) {
 	c, ok := f.contacts[id]
 	if !ok {
@@ -123,6 +133,7 @@ func (f *fakeContactStore) Get(_ context.Context, id uuid.UUID) (contact.Contact
 	return c, nil
 }
 
+// ListContacts returns one page of stored contacts ordered by name then identifier.
 func (f *fakeContactStore) ListContacts(
 	_ context.Context, _, _ string, afterName string, afterID uuid.UUID, limit int,
 ) ([]contact.Contact, error) {
@@ -153,28 +164,33 @@ type fakeTaskStore struct {
 	tasks map[uuid.UUID]task.Task
 }
 
+// newFakeTaskStore returns an empty in memory task store.
 func newFakeTaskStore() *fakeTaskStore {
 	return &fakeTaskStore{tasks: map[uuid.UUID]task.Task{}}
 }
 
+// ListForDay returns no tasks.
 func (f *fakeTaskStore) ListForDay(
 	_ context.Context, _ uuid.UUID, _ time.Time, _ string, _ task.Page,
 ) ([]task.Task, error) {
 	return nil, nil
 }
 
+// ListDueBefore returns no tasks.
 func (f *fakeTaskStore) ListDueBefore(
 	_ context.Context, _ uuid.UUID, _ time.Time, _ string, _ task.Page,
 ) ([]task.Task, error) {
 	return nil, nil
 }
 
+// ListForContact returns no tasks.
 func (f *fakeTaskStore) ListForContact(
 	_ context.Context, _ uuid.UUID, _ string, _ task.Page,
 ) ([]task.Task, error) {
 	return nil, nil
 }
 
+// Create stores one task and reports whether it is new, returning the task already stored under the same origin.
 func (f *fakeTaskStore) Create(_ context.Context, t task.Task) (task.Task, bool, error) {
 	if stored, ok := f.byOrigin(t); ok {
 		return stored, false, nil
@@ -196,6 +212,7 @@ func (f *fakeTaskStore) byOrigin(t task.Task) (task.Task, bool) {
 	return task.Task{}, false
 }
 
+// Update replaces the stored task with the given one.
 func (f *fakeTaskStore) Update(_ context.Context, t task.Task) (task.Task, error) {
 	if _, ok := f.tasks[t.ID]; !ok {
 		return task.Task{}, task.ErrNotFound
@@ -204,6 +221,7 @@ func (f *fakeTaskStore) Update(_ context.Context, t task.Task) (task.Task, error
 	return t, nil
 }
 
+// Get returns the stored task the identifier names.
 func (f *fakeTaskStore) Get(_ context.Context, id uuid.UUID) (task.Task, error) {
 	stored, ok := f.tasks[id]
 	if !ok {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -40,12 +40,14 @@ func (failingTenantStore) TenantForUser(context.Context, uuid.UUID) (tenant.Tena
 	return tenant.Tenant{}, errors.New("tenant store down")
 }
 
+// echoHandler returns a plugin handler writing a fixed body.
 func echoHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("plugin says hi"))
 	})
 }
 
+// newProtectedServer returns a server carrying the echo plugin with one public path, and its user store.
 func newProtectedServer(t *testing.T) (http.Handler, *testkit.Store) {
 	t.Helper()
 	users := newFakeUserStore()

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gopherium/alphone/internal/server"
 )
 
+// spaServer returns a server over an in memory web filesystem holding an index page and one asset.
 func spaServer(t *testing.T) http.Handler {
 	t.Helper()
 	return server.NewServer(server.Config{

--- a/internal/server/streams_test.go
+++ b/internal/server/streams_test.go
@@ -14,6 +14,7 @@ import (
 
 const streamLogin = "ada@example.com"
 
+// blockingPlugin returns a handler that announces each request on the channel and holds until the request is done.
 func blockingPlugin(entered chan<- struct{}) http.Handler {
 	return http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		entered <- struct{}{}
@@ -21,6 +22,7 @@ func blockingPlugin(entered chan<- struct{}) http.Handler {
 	})
 }
 
+// newStreamServer returns a host serving one blocking stub plugin under the given stream lifetime and per user cap.
 func newStreamServer(
 	t *testing.T, users *testkit.Store, entered chan struct{}, lifetime time.Duration, perUser int,
 ) http.Handler {
@@ -35,6 +37,7 @@ func newStreamServer(
 	})
 }
 
+// openPluginRequest starts a request to the path in the background and returns its cancel and its answer channel.
 func openPluginRequest(
 	handler http.Handler,
 	path string,

--- a/internal/server/tokens_test.go
+++ b/internal/server/tokens_test.go
@@ -26,10 +26,12 @@ type fakeTokenStore struct {
 	touched []uuid.UUID
 }
 
+// newFakeTokenStore returns an empty in memory token store.
 func newFakeTokenStore() *fakeTokenStore {
 	return &fakeTokenStore{tokens: map[string]apitoken.Token{}}
 }
 
+// ByHash returns the configured error, the token the hash names, or a not found error.
 func (s *fakeTokenStore) ByHash(_ context.Context, hash string) (apitoken.Token, error) {
 	if s.err != nil {
 		return apitoken.Token{}, s.err
@@ -41,6 +43,7 @@ func (s *fakeTokenStore) ByHash(_ context.Context, hash string) (apitoken.Token,
 	return token, nil
 }
 
+// TouchLastUsed records the touched token id.
 func (s *fakeTokenStore) TouchLastUsed(_ context.Context, id uuid.UUID, _ time.Time) error {
 	s.touched = append(s.touched, id)
 	return nil

--- a/internal/task/changes_test.go
+++ b/internal/task/changes_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gopherium/alphone/internal/task"
 )
 
+// openTask returns one new open task due on a fixed day.
 func openTask(t *testing.T) task.Task {
 	t.Helper()
 	created, err := task.New(task.Input{

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -17,6 +17,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read reports the entropy failure and reads nothing.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -26,10 +26,12 @@ type fakeDispatchStore struct {
 	enqueueAt map[uuid.UUID]error
 }
 
+// newFakeDispatchStore returns a store holding the given subscriptions and no queued deliveries.
 func newFakeDispatchStore(subs ...webhook.Subscription) *fakeDispatchStore {
 	return &fakeDispatchStore{subs: subs, enqueueAt: map[uuid.UUID]error{}}
 }
 
+// ListSubscriptionsForEvent returns the held subscriptions that want the named event.
 func (s *fakeDispatchStore) ListSubscriptionsForEvent(
 	_ context.Context,
 	name event.Name,
@@ -46,6 +48,7 @@ func (s *fakeDispatchStore) ListSubscriptionsForEvent(
 	return matching, nil
 }
 
+// EnqueueDelivery keeps the delivery, or returns the failure set for its subscription.
 func (s *fakeDispatchStore) EnqueueDelivery(_ context.Context, d webhook.Delivery) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -63,6 +66,7 @@ func newDispatcher(store *fakeDispatchStore) (*webhook.Dispatcher, *strings.Buil
 	return webhook.NewDispatcher(store, logger), &logged
 }
 
+// mustSub returns a subscription for the given URL and events, refusing any failure.
 func mustSub(t *testing.T, url string, events ...event.Name) webhook.Subscription {
 	t.Helper()
 	sub, err := webhook.NewSubscription(uuid.Must(uuid.NewV7()), url, events)

--- a/internal/webhook/webhook_internal_test.go
+++ b/internal/webhook/webhook_internal_test.go
@@ -15,6 +15,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read returns the entropy failure instead of any bytes.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/internal/webhook/worker_internal_test.go
+++ b/internal/webhook/worker_internal_test.go
@@ -29,7 +29,7 @@ func (q *countingQueue) ClaimDueDeliveries(_ context.Context, _, _ time.Time, _ 
 	return nil, nil
 }
 
-// SettleDelivery returns the configured settle failure.
+// SettleDelivery returns the configured settlement error.
 func (q *countingQueue) SettleDelivery(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ string) error {
 	return q.settleErr
 }

--- a/internal/webhook/worker_internal_test.go
+++ b/internal/webhook/worker_internal_test.go
@@ -21,6 +21,7 @@ type countingQueue struct {
 	settleErr error
 }
 
+// ClaimDueDeliveries counts the sweep and returns no deliveries.
 func (q *countingQueue) ClaimDueDeliveries(_ context.Context, _, _ time.Time, _ int) ([]ClaimedDelivery, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -28,10 +29,12 @@ func (q *countingQueue) ClaimDueDeliveries(_ context.Context, _, _ time.Time, _ 
 	return nil, nil
 }
 
+// SettleDelivery returns the configured settle failure.
 func (q *countingQueue) SettleDelivery(_ context.Context, _ uuid.UUID, _ string, _ time.Time, _ string) error {
 	return q.settleErr
 }
 
+// sweeps returns how many times the queue was claimed from.
 func (q *countingQueue) sweeps() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/internal/webhook/worker_test.go
+++ b/internal/webhook/worker_test.go
@@ -36,6 +36,7 @@ type fakeWorkerQueue struct {
 	claims   int
 }
 
+// ClaimDueDeliveries returns the pending deliveries and empties them, or the claim failure.
 func (q *fakeWorkerQueue) ClaimDueDeliveries(
 	_ context.Context,
 	_, _ time.Time,
@@ -52,6 +53,7 @@ func (q *fakeWorkerQueue) ClaimDueDeliveries(
 	return claimed, nil
 }
 
+// SettleDelivery records the settlement of one delivery.
 func (q *fakeWorkerQueue) SettleDelivery(
 	_ context.Context,
 	id uuid.UUID,
@@ -65,6 +67,7 @@ func (q *fakeWorkerQueue) SettleDelivery(
 	return nil
 }
 
+// settlements returns a copy of the settlements recorded so far.
 func (q *fakeWorkerQueue) settlements() []settlement {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/plugins/importer/commit_test.go
+++ b/plugins/importer/commit_test.go
@@ -33,6 +33,7 @@ type directory struct {
 	creates    int
 }
 
+// newDirectory returns an empty directory holding no contacts and no identities.
 func newDirectory() *directory {
 	return &directory{
 		contacts:   map[uuid.UUID]sdk.Contact{},
@@ -66,6 +67,7 @@ func (d *directory) seed(name, email string) sdk.Contact {
 	return owner
 }
 
+// FindByIdentity returns the contact owning the given identity.
 func (d *directory) FindByIdentity(
 	_ context.Context, channel sdk.Channel, identifier string,
 ) (sdk.Contact, bool, error) {
@@ -84,6 +86,7 @@ func (d *directory) FindByIdentity(
 	return d.contacts[ownerID], true, nil
 }
 
+// CreateWithIdentities stores a contact owning the given identities, or returns the contact already claiming one.
 func (d *directory) CreateWithIdentities(
 	_ context.Context, name string, identities []sdk.Identity,
 ) (sdk.Contact, bool, error) {
@@ -114,6 +117,7 @@ type recorder struct {
 	data  []map[string]any
 }
 
+// Publish keeps the name and data of one published event.
 func (r *recorder) Publish(_ context.Context, name string, data map[string]any) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/plugins/importer/graphql_test.go
+++ b/plugins/importer/graphql_test.go
@@ -530,8 +530,10 @@ func TestGraphImportMutationsRejectAnUnknownImport(t *testing.T) {
 // brokenReader fails every read with a stream error.
 type brokenReader struct{}
 
+// Read returns a stream error instead of any bytes.
 func (brokenReader) Read([]byte) (int, error) { return 0, errors.New("stream interrupted") }
 
+// Seek reports offset zero without moving anything.
 func (brokenReader) Seek(int64, int) (int64, error) { return 0, nil }
 
 func TestGraphImportUploadReadFailuresPropagate(t *testing.T) {

--- a/plugins/importer/importer_test.go
+++ b/plugins/importer/importer_test.go
@@ -31,6 +31,7 @@ const checkViolation = "23514"
 
 const unreachableDatabaseURL = "postgres://postgres:alphone@localhost:9/postgres?sslmode=disable&connect_timeout=1"
 
+// newTestDatabase returns a config for a core migrated database, skipping the test in short mode.
 func newTestDatabase(t *testing.T) *pgtestdb.Config {
 	t.Helper()
 	if testing.Short() {
@@ -39,6 +40,7 @@ func newTestDatabase(t *testing.T) *pgtestdb.Config {
 	return pgtestdb.Custom(t, testdb.Config(), testdb.Migrator())
 }
 
+// newAssertionPool opens a pool on the given url and closes it at cleanup.
 func newAssertionPool(t *testing.T, url string) *pgxpool.Pool {
 	t.Helper()
 	pool, err := pgxpool.New(t.Context(), url)
@@ -49,6 +51,7 @@ func newAssertionPool(t *testing.T, url string) *pgxpool.Pool {
 	return pool
 }
 
+// newPlugin registers the importer plugin against the given database, stopped at cleanup.
 func newPlugin(t *testing.T, databaseURL string) *importer.Plugin {
 	t.Helper()
 	p, err := importer.Register(sdk.Deps{DatabaseURL: databaseURL})

--- a/plugins/importer/store_internal_test.go
+++ b/plugins/importer/store_internal_test.go
@@ -19,6 +19,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingReader struct{}
 
+// Read returns the entropy failure instead of any bytes.
 func (failingReader) Read([]byte) (int, error) {
 	return 0, errEntropy
 }

--- a/plugins/whatsapp/download_internal_test.go
+++ b/plugins/whatsapp/download_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gopherium/alphone/graph/model"
 )
 
+// seedStoredMedia seeds one message with pending media and marks that media stored.
 func seedStoredMedia(
 	t *testing.T, p *Plugin, externalID string, data []byte, mimeType, filename, sha string,
 ) (uuid.UUID, uuid.UUID) {
@@ -29,6 +30,7 @@ func seedStoredMedia(
 	return conversationID, messageID
 }
 
+// getMedia requests one message's media through the plugin routes with the given headers.
 func getMedia(
 	t *testing.T, p *Plugin, conversationID, messageID string, header http.Header,
 ) *httptest.ResponseRecorder {

--- a/plugins/whatsapp/events_internal_test.go
+++ b/plugins/whatsapp/events_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gopherium/alphone/sdk"
 )
 
+// newMigratedPlugin returns a plugin wired to a fresh test database with its migrations applied.
 func newMigratedPlugin(t *testing.T) *Plugin {
 	t.Helper()
 	if testing.Short() {
@@ -37,6 +38,7 @@ func newMigratedPlugin(t *testing.T) *Plugin {
 	return p
 }
 
+// newIngestReadyPlugin returns a migrated plugin holding a seeded contact and a resolver that always answers it.
 func newIngestReadyPlugin(t *testing.T) *Plugin {
 	t.Helper()
 	p := newMigratedPlugin(t)
@@ -51,6 +53,7 @@ func newIngestReadyPlugin(t *testing.T) *Plugin {
 	return p
 }
 
+// imageMessage returns one inbound image message carrying the given external id.
 func imageMessage(wamid string) inboundMessage {
 	return inboundMessage{
 		externalID:  wamid,
@@ -64,6 +67,7 @@ func imageMessage(wamid string) inboundMessage {
 	}
 }
 
+// tableCount returns how many rows the named table holds.
 func tableCount(t *testing.T, p *Plugin, table string) int {
 	t.Helper()
 	var count int

--- a/plugins/whatsapp/events_test.go
+++ b/plugins/whatsapp/events_test.go
@@ -22,12 +22,14 @@ import (
 	"github.com/gopherium/alphone/sdk"
 )
 
+// sign returns the Meta signature header value for body under the given secret.
 func sign(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
+// eventBody returns a webhook payload carrying one inbound text message from the named contact.
 func eventBody(wamid, waID, name, timestamp, text string) []byte {
 	return fmt.Appendf(nil, `{
 		"object": "whatsapp_business_account",
@@ -39,6 +41,7 @@ func eventBody(wamid, waID, name, timestamp, text string) []byte {
 	}`, waID, name, waID, wamid, timestamp, text)
 }
 
+// postEvent posts body to the webhook route under the given signature and returns the recorder.
 func postEvent(t *testing.T, routes http.Handler, signature string, body []byte) *httptest.ResponseRecorder {
 	t.Helper()
 	request := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
@@ -50,6 +53,7 @@ func postEvent(t *testing.T, routes http.Handler, signature string, body []byte)
 	return recorder
 }
 
+// newIngestingPlugin returns a migrated plugin holding a secret and a phone number, beside its pool.
 func newIngestingPlugin(t *testing.T) (*whatsapp.Plugin, *pgxpool.Pool) {
 	t.Helper()
 	cfg := newTestDatabase(t)
@@ -65,6 +69,7 @@ func newIngestingPlugin(t *testing.T) (*whatsapp.Plugin, *pgxpool.Pool) {
 	return p, pool
 }
 
+// countRows returns the number of rows stored in the named table.
 func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
 	t.Helper()
 	var count int
@@ -210,6 +215,7 @@ func TestWebhookEventsIngestMediaMessages(t *testing.T) {
 	}
 }
 
+// statusEventBody returns a webhook payload carrying one delivery status for the given wamid.
 func statusEventBody(wamid, status string) []byte {
 	return fmt.Appendf(nil, `{
 		"object": "whatsapp_business_account",
@@ -221,6 +227,7 @@ func statusEventBody(wamid, status string) []byte {
 	}`, wamid, status)
 }
 
+// seedOutboundRow stores one contact, conversation and outbound message for the wamid under the tenant.
 func seedOutboundRow(t *testing.T, pool *pgxpool.Pool, wamid string, standing uuid.UUID) {
 	t.Helper()
 	ctx := t.Context()
@@ -250,6 +257,7 @@ func seedOutboundRow(t *testing.T, pool *pgxpool.Pool, wamid string, standing uu
 	}
 }
 
+// messageStatus returns the stored status of the message the wamid names.
 func messageStatus(t *testing.T, pool *pgxpool.Pool, wamid string) *string {
 	t.Helper()
 	var status *string

--- a/plugins/whatsapp/fetcher_internal_test.go
+++ b/plugins/whatsapp/fetcher_internal_test.go
@@ -49,6 +49,7 @@ type graphStub struct {
 	binaryHits   int
 }
 
+// newGraphStub starts a stub graph server answering media metadata and the binary, closed at cleanup.
 func newGraphStub(t *testing.T, binary []byte) *graphStub {
 	t.Helper()
 	s := &graphStub{
@@ -63,6 +64,7 @@ func newGraphStub(t *testing.T, binary []byte) *graphStub {
 	return s
 }
 
+// handle records the request authorization and answers either the media metadata or the binary.
 func (s *graphStub) handle(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -98,23 +100,27 @@ func (s *graphStub) handle(w http.ResponseWriter, r *http.Request) {
 		downloadURL, s.mimeType, s.fileSize)
 }
 
+// hits returns how many metadata and binary requests the stub answered.
 func (s *graphStub) hits() (int, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.metadataHits, s.binaryHits
 }
 
+// headers returns a copy of the Authorization headers the stub received.
 func (s *graphStub) headers() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.authHeaders...)
 }
 
+// shaOf returns the base64 encoded sha256 sum of the given bytes.
 func shaOf(data []byte) string {
 	sum := sha256.Sum256(data)
 	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
+// newTestFetcher gives the plugin environment credentials and returns a fetcher over its store and events.
 func newTestFetcher(t *testing.T, p *Plugin, baseURL string, maxBytes int64) *mediaFetcher {
 	t.Helper()
 	p.envCredentials = credentials{phoneNumberID: "PN1", accessToken: "test-token"}
@@ -127,6 +133,7 @@ func newTestFetcher(t *testing.T, p *Plugin, baseURL string, maxBytes int64) *me
 	})
 }
 
+// seedPendingImage stores one message with a pending media row and returns the message id.
 func seedPendingImage(t *testing.T, p *Plugin, externalID, sha string) uuid.UUID {
 	t.Helper()
 	_, messageID := seedMessage(t, p, externalID)
@@ -145,6 +152,7 @@ type mediaRowState struct {
 	fileSize  *int64
 }
 
+// mediaState reads the media row the message names, failing the test when it cannot be read.
 func mediaState(t *testing.T, p *Plugin, messageID uuid.UUID) mediaRowState {
 	t.Helper()
 	var s mediaRowState
@@ -159,6 +167,7 @@ func mediaState(t *testing.T, p *Plugin, messageID uuid.UUID) mediaRowState {
 	return s
 }
 
+// mediaStatus returns the status of the media row the message names, empty when there is none.
 func mediaStatus(p *Plugin, messageID uuid.UUID) string {
 	var status string
 	_ = p.pool.QueryRow(context.Background(),

--- a/plugins/whatsapp/media_internal_test.go
+++ b/plugins/whatsapp/media_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// seedMessage stores one contact, one open conversation and one inbound image message.
 func seedMessage(t *testing.T, p *Plugin, externalID string) (uuid.UUID, uuid.UUID) {
 	t.Helper()
 	ctx := t.Context()
@@ -41,6 +42,7 @@ func seedMessage(t *testing.T, p *Plugin, externalID string) (uuid.UUID, uuid.UU
 	return conversationID, messageID
 }
 
+// insertPendingMedia stores one pending media row for the named message.
 func insertPendingMedia(t *testing.T, p *Plugin, messageID uuid.UUID, d mediaDescriptor) {
 	t.Helper()
 	if err := insertMediaPending(t.Context(), p.pool, messageID, d); err != nil {

--- a/plugins/whatsapp/parse_internal_test.go
+++ b/plugins/whatsapp/parse_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// webhookBody returns a webhook payload wrapping the given message element.
 func webhookBody(message string) []byte {
 	return fmt.Appendf(nil, `{
 		"object": "whatsapp_business_account",
@@ -19,6 +20,7 @@ func webhookBody(message string) []byte {
 	}`, message)
 }
 
+// envelope returns one message element of the given id and type carrying the extra fields.
 func envelope(id, kind, fields string) string {
 	return fmt.Sprintf(`{"from": "184467235", "id": %q, "timestamp": "1751791000", "type": %q%s}`,
 		id, kind, fields)
@@ -250,6 +252,7 @@ func TestParseMessagesRejectsEnvelopeGarbage(t *testing.T) {
 	}
 }
 
+// statusEnvelope returns a webhook payload wrapping the given status elements.
 func statusEnvelope(statuses string) []byte {
 	return fmt.Appendf(nil, `{
 		"object": "whatsapp_business_account",

--- a/plugins/whatsapp/publish_test.go
+++ b/plugins/whatsapp/publish_test.go
@@ -20,6 +20,7 @@ type recordingPublisher struct {
 	data      []map[string]any
 }
 
+// Publish records the event name and its data.
 func (p *recordingPublisher) Publish(_ context.Context, name string, data map[string]any) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -27,6 +28,7 @@ func (p *recordingPublisher) Publish(_ context.Context, name string, data map[st
 	p.data = append(p.data, data)
 }
 
+// names returns a copy of the event names recorded so far.
 func (p *recordingPublisher) names() []string {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/plugins/whatsapp/seed_internal_test.go
+++ b/plugins/whatsapp/seed_internal_test.go
@@ -21,6 +21,7 @@ type seedResolver struct {
 	resolver *contact.Resolver
 }
 
+// Resolve returns the core contact for the identifier as an sdk contact.
 func (r seedResolver) Resolve(
 	ctx context.Context,
 	channel sdk.Channel,
@@ -37,10 +38,12 @@ type erroringResolver struct {
 	err error
 }
 
+// Resolve returns the stored failure for every call.
 func (r erroringResolver) Resolve(context.Context, sdk.Channel, string, string) (sdk.Contact, error) {
 	return sdk.Contact{}, r.err
 }
 
+// newSeedReadyPlugin returns a migrated plugin whose resolver stores contacts in the core tables.
 func newSeedReadyPlugin(t *testing.T) *Plugin {
 	t.Helper()
 	p := newMigratedPlugin(t)
@@ -48,6 +51,7 @@ func newSeedReadyPlugin(t *testing.T) *Plugin {
 	return p
 }
 
+// seedCounts returns the row counts of the conversations, messages, media and contacts tables.
 func seedCounts(t *testing.T, p *Plugin) [4]int {
 	t.Helper()
 	return [4]int{
@@ -58,6 +62,7 @@ func seedCounts(t *testing.T, p *Plugin) [4]int {
 	}
 }
 
+// collectStrings returns the single string column the query answers, in row order.
 func collectStrings(t *testing.T, p *Plugin, query string) []string {
 	t.Helper()
 	rows, err := p.pool.Query(t.Context(), query)
@@ -79,6 +84,7 @@ func collectStrings(t *testing.T, p *Plugin, query string) []string {
 	return values
 }
 
+// conversationActivity returns the last activity time of every conversation by external id.
 func conversationActivity(t *testing.T, p *Plugin) map[string]time.Time {
 	t.Helper()
 	rows, err := p.pool.Query(t.Context(),
@@ -102,6 +108,7 @@ func conversationActivity(t *testing.T, p *Plugin) map[string]time.Time {
 	return activity
 }
 
+// assertSeededDataSet fails the test unless the seeded counts, statuses, media and orders all match.
 func assertSeededDataSet(t *testing.T, p *Plugin) {
 	t.Helper()
 	if got, want := seedCounts(t, p), [4]int{3, 8, 1, 3}; got != want {

--- a/plugins/whatsapp/send_test.go
+++ b/plugins/whatsapp/send_test.go
@@ -30,6 +30,7 @@ type graphStub struct {
 	server   *httptest.Server
 }
 
+// newGraphStub starts a stub graph server that records each call and answers a canned response.
 func newGraphStub(t *testing.T) *graphStub {
 	t.Helper()
 	stub := &graphStub{status: http.StatusOK, body: `{"messages":[{"id":"wamid.out.1"}]}`}
@@ -48,6 +49,7 @@ func newGraphStub(t *testing.T) *graphStub {
 	return stub
 }
 
+// newSendingHarness returns a migrated plugin wired to a stub graph server, together with that stub and the pool.
 func newSendingHarness(
 	t *testing.T, envOverrides map[string]string,
 ) (*whatsapp.Plugin, *graphStub, *pgxpool.Pool) {
@@ -72,6 +74,7 @@ func newSendingHarness(
 	return p, stub, pool
 }
 
+// newSendingPlugin returns the migrated plugin and stub graph server of a sending harness.
 func newSendingPlugin(t *testing.T, envOverrides map[string]string) (*whatsapp.Plugin, *graphStub) {
 	t.Helper()
 	p, stub, _ := newSendingHarness(t, envOverrides)
@@ -315,6 +318,7 @@ func TestSendMessageRejectsMisconfiguredGraphURL(t *testing.T) {
 
 type failingEntropy struct{}
 
+// Read returns an entropy failure instead of random bytes.
 func (failingEntropy) Read([]byte) (int, error) {
 	return 0, errors.New("entropy exhausted")
 }

--- a/plugins/whatsapp/status_internal_test.go
+++ b/plugins/whatsapp/status_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gopherium/alphone/sdk"
 )
 
+// seedOutboundMessage stores a contact, a conversation and one outbound message, and returns the conversation id.
 func seedOutboundMessage(t *testing.T, p *Plugin, externalID string) uuid.UUID {
 	t.Helper()
 	ctx := t.Context()
@@ -43,6 +44,7 @@ func seedOutboundMessage(t *testing.T, p *Plugin, externalID string) uuid.UUID {
 	return conversationID
 }
 
+// messageStatusOf returns the stored status and status detail of the message the wamid names.
 func messageStatusOf(t *testing.T, p *Plugin, wamid string) (*string, *string) {
 	t.Helper()
 	var status, detail *string
@@ -55,6 +57,7 @@ func messageStatusOf(t *testing.T, p *Plugin, wamid string) (*string, *string) {
 	return status, detail
 }
 
+// drainEvents takes every event already waiting on the subscription.
 func drainEvents(subscription chan event) {
 	for {
 		select {
@@ -65,6 +68,7 @@ func drainEvents(subscription chan event) {
 	}
 }
 
+// applyStatusOK applies one status update, failing the test on any error.
 func applyStatusOK(t *testing.T, p *Plugin, u statusUpdate) {
 	t.Helper()
 	if err := p.applyStatus(t.Context(), u); err != nil {
@@ -72,6 +76,7 @@ func applyStatusOK(t *testing.T, p *Plugin, u statusUpdate) {
 	}
 }
 
+// assertStatus fails the test unless the message the wamid names carries the wanted status.
 func assertStatus(t *testing.T, p *Plugin, wamid, want string) {
 	t.Helper()
 	status, _ := messageStatusOf(t, p, wamid)

--- a/plugins/whatsapp/store_internal_test.go
+++ b/plugins/whatsapp/store_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// seedPreviewConversation stores one conversation with a single inbound message and returns its id.
 func seedPreviewConversation(
 	t *testing.T, p *Plugin, contactID uuid.UUID, externalID, contentType, content string,
 ) uuid.UUID {

--- a/plugins/whatsapp/whatsapp_internal_test.go
+++ b/plugins/whatsapp/whatsapp_internal_test.go
@@ -21,6 +21,7 @@ var errEntropy = errors.New("entropy source failed")
 
 type failingEntropy struct{}
 
+// Read always fails with the entropy error.
 func (failingEntropy) Read([]byte) (int, error) {
 	return 0, errEntropy
 }
@@ -29,10 +30,12 @@ type staticResolver struct {
 	owner sdk.Contact
 }
 
+// Resolve returns the same owner contact for every lookup.
 func (s staticResolver) Resolve(_ context.Context, _ sdk.Channel, _, _ string) (sdk.Contact, error) {
 	return s.owner, nil
 }
 
+// newUnreachablePool returns a connection pool pointed at a database that refuses every connection.
 func newUnreachablePool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	pool, err := pgxpool.New(t.Context(), "postgres://postgres:x@localhost:9/postgres?sslmode=disable&connect_timeout=1")

--- a/plugins/whatsapp/whatsapp_test.go
+++ b/plugins/whatsapp/whatsapp_test.go
@@ -32,6 +32,7 @@ type resolverBridge struct {
 	resolver *contact.Resolver
 }
 
+// Resolve resolves the identifier through the core resolver and returns it as an sdk contact.
 func (b resolverBridge) Resolve(
 	ctx context.Context,
 	channel sdk.Channel,
@@ -48,6 +49,7 @@ const uniqueViolation = "23505"
 
 const unreachableDatabaseURL = "postgres://postgres:alphone@localhost:9/postgres?sslmode=disable&connect_timeout=1"
 
+// newTestDatabase returns a config for a core migrated database, skipping the test in short mode.
 func newTestDatabase(t *testing.T) *pgtestdb.Config {
 	t.Helper()
 	if testing.Short() {
@@ -56,6 +58,7 @@ func newTestDatabase(t *testing.T) *pgtestdb.Config {
 	return pgtestdb.Custom(t, testdb.Config(), testdb.Migrator())
 }
 
+// newAssertionPool opens a pool on the given url and closes it at cleanup.
 func newAssertionPool(t *testing.T, url string) *pgxpool.Pool {
 	t.Helper()
 	pool, err := pgxpool.New(t.Context(), url)
@@ -66,6 +69,7 @@ func newAssertionPool(t *testing.T, url string) *pgxpool.Pool {
 	return pool
 }
 
+// newPlugin registers the whatsapp plugin with the given database, resolver and environment, stopped at cleanup.
 func newPlugin(t *testing.T, databaseURL string, resolver sdk.ContactResolver, env map[string]string) *whatsapp.Plugin {
 	t.Helper()
 	p, err := whatsapp.Register(sdk.Deps{


### PR DESCRIPTION
Closes #97

## What

Every helper function and method in a test file now carries a one line docblock naming what it does, closing a gap of 173 across 49 files. Test functions still carry none, which is the convention every one of the 1199 already follows. A `.coderabbit.yaml` states both conventions to the reviewer, along with the rules on comments in Go and SQL and on fuzzy translations, so the same findings stop arriving each round.

Nothing but comments changed in the test files. The diff adds 173 comment lines and no code line at all.

## Why

The split was 386 helpers documented against 173 bare, which reads as an accident rather than a choice, and a reader meeting a bare `seedStoredMedia` had to read its body to learn that it seeds a message, attaches pending media and then marks that media stored. Each new line was written from the body rather than the name, so it says what the helper actually does instead of restating its identifier.

Test functions are the opposite case and stay as they are. Their names already carry the intent, a docblock limited to WHAT could only repeat the name, and the absence of one is what keeps the pressure on the name where it belongs. The Go tooling agrees, since no test doc comment is ever rendered anywhere.

The config exists because the same two requests arrived in four separate review rounds. Encoding a convention once is cheaper than declining it every time, and it lets a genuine finding stand out instead of being buried under a preference the repository has already settled.

## Testing Instructions

1. Open `plugins/whatsapp/download_internal_test.go` and read the line above `seedStoredMedia`. Compare it with the body and confirm it names all three steps rather than restating the function name. Do the same for `seedMessage` in `plugins/whatsapp/media_internal_test.go` and `testDatabaseURL` in `cmd/alphone/main_test.go`.
2. Confirm no test function gained a comment:
   ```
   git diff origin/main..HEAD -- '*_test.go' | grep -B1 "^+func Test"
   ```
   It prints nothing, since every added line sits above a helper.
3. Confirm the diff carries no code change:
   ```
   git diff -U0 origin/main..HEAD -- '*_test.go' | grep "^+" | grep -v "^+++" | grep -v "^+\s*//"
   ```
   It prints nothing.
4. Confirm the config is valid and comment free, since this repository allows no YAML comments:
   ```
   python3 -c "import yaml; print(len(yaml.safe_load(open('.coderabbit.yaml'))['reviews']['path_instructions']), 'path entries')"
   grep -n '#' .coderabbit.yaml
   ```
   The first prints `4 path entries` and the second prints nothing.
5. Read this pull request's own automated review when it arrives. It is the live check on the config: no comment should ask for a doc comment on a function whose name begins with Test.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved comments throughout test code to clarify helper behavior, test fixtures, failure scenarios, and setup steps.
  * Added review guidance for Go documentation, test comments, SQL migrations, and fuzzy translations.
* **Chores**
  * Standardized documentation expectations for test helpers without changing application behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR documents previously undocumented test helpers and adds reviewer guidance that codifies the repository’s comment conventions.
- Adds one-line doc comments to helper functions and methods across 49 test files.
- Adds `.coderabbit.yaml` instructions for Go, test, SQL migration, and translation reviews.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["test(webhook): say what the fake queue s..."](https://github.com/gopherium/alphone/commit/beb29d4557360668e1062f7946c94e0b6d56d4a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57060396)</sub>

<!-- /greptile_comment -->