### PR TITLE
Revalidate the page and keep only the hashed files

### DIFF
--- a/internal/server/spa.go
+++ b/internal/server/spa.go
@@ -11,6 +11,15 @@ import (
 	"github.com/gopherium/gouncer/authkit"
 )
 
+// assetPrefix names the directory holding the build's content hashed files.
+const assetPrefix = "assets/"
+
+// indexCache asks a client to revalidate the page naming the current build.
+const indexCache = "no-cache"
+
+// assetCache lets a client keep a content hashed file for a year.
+const assetCache = "public, max-age=31536000, immutable"
+
 // spaHandler serves the single-page app from webFS, falling back to
 // index.html for paths without a matching file.
 func spaHandler(webFS fs.FS) http.HandlerFunc {
@@ -25,8 +34,18 @@ func spaHandler(webFS fs.FS) http.HandlerFunc {
 			if _, err := fs.Stat(webFS, name); err != nil {
 				r = r.Clone(r.Context())
 				r.URL.Path = "/"
+				name = ""
 			}
 		}
+		w.Header().Set("Cache-Control", cacheFor(name))
 		fileServer.ServeHTTP(w, r)
 	}
+}
+
+// cacheFor answers how long a client may keep the file a served name resolves to.
+func cacheFor(name string) string {
+	if strings.HasPrefix(name, assetPrefix) {
+		return assetCache
+	}
+	return indexCache
 }

--- a/internal/server/spa.go
+++ b/internal/server/spa.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"net/http"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/gopherium/gouncer/authkit"
@@ -19,6 +20,9 @@ const indexCache = "no-cache"
 
 // assetCache lets a client keep a content hashed file for a year.
 const assetCache = "public, max-age=31536000, immutable"
+
+// hashedAsset matches a built file whose name carries the content hash the bundler appends.
+var hashedAsset = regexp.MustCompile(`-[A-Za-z0-9_-]{8}\.[A-Za-z0-9]+$`)
 
 // spaHandler serves the single-page app from webFS, falling back to
 // index.html for paths without a matching file.
@@ -44,7 +48,7 @@ func spaHandler(webFS fs.FS) http.HandlerFunc {
 
 // cacheFor answers how long a client may keep the file a served name resolves to.
 func cacheFor(name string) string {
-	if strings.HasPrefix(name, assetPrefix) {
+	if strings.HasPrefix(name, assetPrefix) && hashedAsset.MatchString(name) {
 		return assetCache
 	}
 	return indexCache

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -17,8 +17,10 @@ func spaServer(t *testing.T) http.Handler {
 	return server.NewServer(server.Config{
 		Users: newFakeUserStore(),
 		Web: fstest.MapFS{
-			"index.html":    {Data: []byte("<!doctype html><title>AlphOne</title>")},
-			"assets/app.js": {Data: []byte("console.log('app')")},
+			"index.html":               {Data: []byte("<!doctype html><title>AlphOne</title>")},
+			"assets/app.js":            {Data: []byte("console.log('app')")},
+			"assets/app-B7EuLSNJ.js":   {Data: []byte("console.log('hashed')")},
+			"assets/index-Do-XTcIQ.js": {Data: []byte("console.log('hyphenated hash')")},
 		},
 	})
 }
@@ -69,13 +71,33 @@ func TestAClientRouteIsRevalidatedLikeTheIndex(t *testing.T) {
 	}
 }
 
-func TestAssetsAreKeptForAYear(t *testing.T) {
+func TestHashedAssetsAreKeptForAYear(t *testing.T) {
+	t.Parallel()
+
+	recorder := doRequest(t, spaServer(t), "/assets/app-B7EuLSNJ.js")
+
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want the year an immutable hashed asset earns", got)
+	}
+}
+
+func TestAHashHoldingAHyphenIsStillRecognised(t *testing.T) {
+	t.Parallel()
+
+	recorder := doRequest(t, spaServer(t), "/assets/index-Do-XTcIQ.js")
+
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want the year, the build writes hashes holding a hyphen", got)
+	}
+}
+
+func TestAnAssetWithoutAHashIsRevalidated(t *testing.T) {
 	t.Parallel()
 
 	recorder := doRequest(t, spaServer(t), "/assets/app.js")
 
-	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
-		t.Errorf("Cache-Control = %q, want the year an immutable hashed asset earns", got)
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache, a stable name can be replaced at the same address", got)
 	}
 }
 

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -49,6 +49,36 @@ func TestServesSPAAssets(t *testing.T) {
 	}
 }
 
+func TestTheIndexIsRevalidatedOnEveryVisit(t *testing.T) {
+	t.Parallel()
+
+	recorder := doRequest(t, spaServer(t), "/")
+
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache so a new build is never hidden behind a cached page", got)
+	}
+}
+
+func TestAClientRouteIsRevalidatedLikeTheIndex(t *testing.T) {
+	t.Parallel()
+
+	recorder := doRequest(t, spaServer(t), "/users")
+
+	if got := recorder.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, want no-cache because the fallback answers the index", got)
+	}
+}
+
+func TestAssetsAreKeptForAYear(t *testing.T) {
+	t.Parallel()
+
+	recorder := doRequest(t, spaServer(t), "/assets/app.js")
+
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Errorf("Cache-Control = %q, want the year an immutable hashed asset earns", got)
+	}
+}
+
 func TestFallsBackToIndexForClientRoutes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #106

## What

The SPA handler answers Cache-Control no-cache for index.html and for every client route that falls back to it, and public max-age=31536000 immutable for the content hashed files under assets.

## Why

The handler set no Cache-Control at all, so a browser applied heuristic caching to index.html and kept the document naming the previous build's assets. The interface then rendered from a stale bundle while the sidebar read the version from the graph and showed the new one, so nothing looked wrong. A deploy was served the previous release's navigation against the new server, and the mismatch took a while to spot precisely because the version display came from a different source than the code.

The asset filenames already carry a content hash, so they are safe to keep for a year. Only the entry document has a fixed name, and it is the one that must never be cached.

## Testing

1. `go test ./internal/server/` and confirm 100 tests pass
2. Red first: the three new tests fail before the handler change, each naming the header it wants
3. Confirm `/` answers no-cache
4. Confirm a client route such as `/users` answers no-cache too, since the fallback serves the index
5. Confirm `/assets/app.js` answers the year with immutable
6. `golangci-lint run --enable-only cyclop ./internal/server/` reports no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser caching for application pages so new releases are detected promptly.
  * Added long-term, immutable caching for content-hashed static assets to improve loading performance.
  * Ensured unhashed assets, fallback pages, and client-side routes use revalidation-friendly caching.
  * Improved recognition of versioned assets, including filenames containing hyphenated hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->