### PR TITLE
Send our translation drafts to the platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ catalogs:
 translations:
 	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/sync-translations.ts
 
+translations-push:
+	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/push-translations.ts
+
 translations-retire:
 	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/retire-translations.ts
 

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ pot:
 catalogs:
 	pnpm --filter @alphone/frontend exec node scripts/write-catalogs.ts
 
-translations:
+translations: pot
 	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/sync-translations.ts
 
-translations-push:
+translations-push: pot
 	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/push-translations.ts
 
-translations-retire:
+translations-retire: pot
 	cd frontend && node --env-file-if-exists=$(CURDIR)/.env scripts/retire-translations.ts
 
 outdated:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
 		"@alphone/plugin-importer": "workspace:*",
 		"@alphone/plugin-whatsapp": "workspace:*",
 		"@gopherium/godmin": "0.7.0",
-		"@gopherium/gottext": "0.2.0",
+		"@gopherium/gottext": "0.4.0",
 		"@gopherium/react-auth": "0.8.0",
 		"@tanstack/react-query": "^5.101.4",
 		"@tanstack/react-router": "^1.170.23",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
 		"pot": "node scripts/write-pot.ts",
 		"preview": "vite preview",
 		"translations": "node --env-file-if-exists=../.env scripts/sync-translations.ts",
+		"translations:push": "node --env-file-if-exists=../.env scripts/push-translations.ts",
 		"translations:retire": "node --env-file-if-exists=../.env scripts/retire-translations.ts",
 		"typecheck": "tsc -b"
 	},

--- a/frontend/scripts/push-translations.ts
+++ b/frontend/scripts/push-translations.ts
@@ -27,19 +27,23 @@ if (token === undefined) {
 const root = repositoryRoot()
 const locales = supportedLocales(root)
 
-let uploaded = false
-
-for (const domain of domains()) {
-	if (uploaded) {
-		await pause(UPLOAD_SPACING_MS)
-	}
-	uploaded = true
+const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
 	const project = process.env[variable]
 	if (project === undefined) {
 		console.error(`set ${variable} to push ${domain.name}`)
 		process.exit(1)
 	}
+	return { domain, project }
+})
+
+let uploaded = false
+
+for (const { domain, project } of targets) {
+	if (uploaded) {
+		await pause(UPLOAD_SPACING_MS)
+	}
+	uploaded = true
 	const languages = join(root, domain.languages)
 	const done = await pushTranslations(
 		poeditorAt({ token, project, domain: domain.name }),

--- a/frontend/scripts/push-translations.ts
+++ b/frontend/scripts/push-translations.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { poeditorAt, pushTranslations } from '@gopherium/gottext/sync'
+
+import { domains, projectVariable, repositoryRoot } from './config.ts'
+import { supportedLocales } from './locales.ts'
+
+/** UPLOAD_SPACING_MS is the wait between two uploads. */
+const UPLOAD_SPACING_MS = 25_000
+
+/**
+ * Waits the given milliseconds.
+ * @param ms - How long to wait.
+ * @returns A promise settling once the wait is over.
+ */
+function pause(ms: number): Promise<void> {
+	return new Promise((settle) => setTimeout(settle, ms))
+}
+
+const token = process.env.POEDITOR_API_TOKEN
+if (token === undefined) {
+	console.error('set POEDITOR_API_TOKEN to push translations')
+	process.exit(1)
+}
+
+const root = repositoryRoot()
+const locales = supportedLocales(root)
+
+let uploaded = false
+
+for (const domain of domains()) {
+	if (uploaded) {
+		await pause(UPLOAD_SPACING_MS)
+	}
+	uploaded = true
+	const variable = projectVariable(domain.name)
+	const project = process.env[variable]
+	if (project === undefined) {
+		console.error(`set ${variable} to push ${domain.name}`)
+		process.exit(1)
+	}
+	const languages = join(root, domain.languages)
+	const done = await pushTranslations(
+		poeditorAt({ token, project, domain: domain.name }),
+		locales,
+		{
+			read: (locale) => {
+				const target = join(languages, `${locale}.po`)
+				return existsSync(target) ? readFileSync(target, 'utf8') : undefined
+			},
+			write: () => {},
+		},
+		readFileSync(join(languages, `${domain.name}.pot`), 'utf8'),
+	)
+	console.log(
+		done.pushed.length === 0
+			? `${domain.name}: no catalogue pushed`
+			: `${domain.name}: catalogues pushed: ${done.pushed.join(', ')}`,
+	)
+	for (const held of done.added) {
+		console.log(`${domain.name}: added ${held}`)
+	}
+	for (const held of done.skipped) {
+		console.log(`${domain.name}: skipped ${held}`)
+	}
+}

--- a/frontend/scripts/push-translations.ts
+++ b/frontend/scripts/push-translations.ts
@@ -29,8 +29,8 @@ const locales = supportedLocales(root)
 
 const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
-	const project = process.env[variable]
-	if (project === undefined) {
+	const project = process.env[variable]?.trim()
+	if (project === undefined || project === '') {
 		console.error(`set ${variable} to push ${domain.name}`)
 		process.exit(1)
 	}

--- a/frontend/scripts/retire-translations.ts
+++ b/frontend/scripts/retire-translations.ts
@@ -17,8 +17,8 @@ const root = repositoryRoot()
 
 const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
-	const project = process.env[variable]
-	if (project === undefined) {
+	const project = process.env[variable]?.trim()
+	if (project === undefined || project === '') {
 		console.error(`set ${variable} to retire ${domain.name}`)
 		process.exit(1)
 	}

--- a/frontend/scripts/retire-translations.ts
+++ b/frontend/scripts/retire-translations.ts
@@ -15,13 +15,17 @@ if (token === undefined) {
 
 const root = repositoryRoot()
 
-for (const domain of domains()) {
+const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
 	const project = process.env[variable]
 	if (project === undefined) {
 		console.error(`set ${variable} to retire ${domain.name}`)
 		process.exit(1)
 	}
+	return { domain, project }
+})
+
+for (const { domain, project } of targets) {
 	const template = readFileSync(join(root, domain.languages, `${domain.name}.pot`), 'utf8')
 	const deleted = await poeditorAt({ token, project, domain: domain.name }).retireTerms(template)
 	console.log(

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -29,19 +29,23 @@ if (token === undefined) {
 const root = repositoryRoot()
 const locales = supportedLocales(root)
 
-let uploaded = false
-
-for (const domain of domains()) {
-	if (uploaded) {
-		await pause(UPLOAD_SPACING_MS)
-	}
-	uploaded = true
+const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
 	const project = process.env[variable]
 	if (project === undefined) {
 		console.error(`set ${variable} to sync ${domain.name}`)
 		process.exit(1)
 	}
+	return { domain, project }
+})
+
+let uploaded = false
+
+for (const { domain, project } of targets) {
+	if (uploaded) {
+		await pause(UPLOAD_SPACING_MS)
+	}
+	uploaded = true
 	const languages = join(root, domain.languages)
 	mkdirSync(languages, { recursive: true })
 	const done = await syncTranslations(

--- a/frontend/scripts/sync-translations.ts
+++ b/frontend/scripts/sync-translations.ts
@@ -31,8 +31,8 @@ const locales = supportedLocales(root)
 
 const targets = domains().map((domain) => {
 	const variable = projectVariable(domain.name)
-	const project = process.env[variable]
-	if (project === undefined) {
+	const project = process.env[variable]?.trim()
+	if (project === undefined || project === '') {
 		console.error(`set ${variable} to sync ${domain.name}`)
 		process.exit(1)
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@tanstack/react-router@1.170.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/style-runtime@0.8.0)(@wordpress/theme@1.1.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vitest@4.1.10)
       '@gopherium/gottext':
-        specifier: 0.2.0
-        version: 0.2.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
+        specifier: 0.4.0
+        version: 0.4.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
       '@gopherium/react-auth':
         specifier: 0.8.0
         version: 0.8.0(@tanstack/react-query@5.101.4(react@19.2.8))(@testing-library/jest-dom@6.9.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/i18n@6.26.0)(@wordpress/theme@1.1.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(react@19.2.8)(vitest@4.1.10)
@@ -249,8 +249,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@tanstack/react-router@1.170.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/style-runtime@0.8.0)(@wordpress/theme@1.1.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vitest@4.1.10)
       '@gopherium/gottext':
-        specifier: 0.2.0
-        version: 0.2.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
+        specifier: 0.4.0
+        version: 0.4.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)
       '@gopherium/react-auth':
         specifier: 0.8.0
         version: 0.8.0(@tanstack/react-query@5.101.4(react@19.2.8))(@testing-library/jest-dom@6.9.1)(@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@wordpress/i18n@6.26.0)(@wordpress/theme@1.1.0(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(@wordpress/ui@0.19.0(@date-fns/tz@1.5.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(date-fns@4.4.0)(esbuild@0.28.1)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(stylelint@17.14.1(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(react@19.2.8)(vitest@4.1.10)
@@ -931,8 +931,8 @@ packages:
       vitest:
         optional: true
 
-  '@gopherium/gottext@0.2.0':
-    resolution: {integrity: sha512-Pr6whkn01B+b/lXe6ry2kIXtO18G3SJPyMW4NFYWdXnZOBAtqNafmwyv9lTTdn634li+RMSGL0Ej7wqngUDm/A==}
+  '@gopherium/gottext@0.4.0':
+    resolution: {integrity: sha512-3+ugYk1CG3o22lWEFABRdqvFt7B0kMDlTdcc3fVM3dgoYCjTAFm4Xb+YM+co6YdaXTNOzn66dQMB/p2lWVcc0A==}
     engines: {node: '>=22'}
     peerDependencies:
       '@wordpress/i18n': 6.26.0
@@ -5485,7 +5485,7 @@ snapshots:
       stylelint: 17.14.1(typescript@6.0.3)
       vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.1(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
-  '@gopherium/gottext@0.2.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)':
+  '@gopherium/gottext@0.4.0(@wordpress/i18n@6.26.0)(gettext-extractor@4.0.6)':
     dependencies:
       '@wordpress/i18n': 6.26.0
       gettext-parser: 9.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ packages:
 minimumReleaseAgeExclude:
   - '@gopherium/godmin'
   - '@gopherium/react-auth@0.6.0 || 0.8.0'
-  - '@gopherium/gottext@0.2.0'
+  - '@gopherium/gottext@0.4.0'
 
 overrides:
   react: ^19.2.8

--- a/sdk/frontend/package.json
+++ b/sdk/frontend/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"@gopherium/godmin": "0.7.0",
-		"@gopherium/gottext": "0.2.0",
+		"@gopherium/gottext": "0.4.0",
 		"@gopherium/react-auth": "0.8.0",
 		"@tanstack/react-query": "^5.101.4",
 		"@urql/exchange-graphcache": "9.0.1",

--- a/test/features/features/mcp-tasks.feature
+++ b/test/features/features/mcp-tasks.feature
@@ -15,9 +15,9 @@ Feature: An agent lists tasks
     And the task "Call Maria Perez back" names its contact "Maria Perez"
 
   Scenario: A chosen day lists only that day
-    Given an open task "Prepare the renewal" due on 2026-09-01
+    Given an open task "Prepare the renewal" due on 2020-01-15
     And an open task "Send the quote" due today
-    When the agent calls list_my_tasks for 2026-09-01
+    When the agent calls list_my_tasks for 2020-01-15
     Then the answer lists 1 task
     And the task "Prepare the renewal" is listed
 


### PR DESCRIPTION
Closes #111

## What

The translation brick moves to 0.4.0. A new push script sends our Spanish drafts up to the platform, so translators can finally review them. It never overwrites an answer a translator already settled, and it keeps the fuzzy marks so they know what is machine written.

## Why

The weekly job only ever pulled finished work down. Our drafts had no way up. All four catalogs are fully drafted and none of it has reached a translator.

## Testing

The push talks to the live platform, so it is run by hand, not in CI:

```bash
make translations-push
```

It needs POEDITOR_API_TOKEN and the four project ids in a local .env file. Without them it stops with a clear message and changes nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a translation publishing workflow for sending locale catalogs to the translation management service.
  - Added commands for generating and publishing translations through standard development tooling.
  - Missing locale files are skipped automatically, with clear reporting of pushed, added, and skipped catalogs.

- **Improvements**
  - Translation settings are validated before synchronization, publishing, or retirement begins.
  - Publishing requests are paced to support reliable uploads across multiple translation domains.
  - Improved handling prevents partial processing when configuration is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->