### PR TITLE
feat(graphres): place invited accounts in the inviter's tenant

### DIFF
--- a/cmd/alphone/inviteplacement_test.go
+++ b/cmd/alphone/inviteplacement_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package main
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	authkitpg "github.com/gopherium/gouncer/authkit/postgres"
+
+	"github.com/gopherium/alphone/internal/postgres"
+)
+
+// placedAdminTenant stands the seeded admin in a fresh tenant, answering the tenant id and a pool on the database.
+func placedAdminTenant(t *testing.T, databaseURL string) (uuid.UUID, *pgxpool.Pool) {
+	t.Helper()
+	pool, err := pgxpool.New(t.Context(), databaseURL)
+	if err != nil {
+		t.Fatalf("connecting pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	admin, err := authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("reading the seeded admin: %v", err)
+	}
+	acme := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenant_members (user_id, tenant_id) VALUES ($1, $2)", admin.ID, acme); err != nil {
+		t.Fatalf("placing the admin: %v", err)
+	}
+	return acme, pool
+}
+
+func TestRunPlacesAnInvitedAccountInTheInvitersTenant(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping database test in short mode")
+	}
+	addr := freeAddr(t)
+	databaseURL := testDatabaseURL(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- run(ctx, testGetenv(map[string]string{
+			"ALPHONE_DATABASE_URL": databaseURL,
+			"ALPHONE_ADDR":         addr,
+		}), io.Discard, registerPlugins)
+	}()
+	t.Cleanup(func() { stopRun(t, cancel, runErr) })
+
+	baseURL := "http://" + addr
+	waitForServer(t, baseURL)
+	seedAdmin(t, databaseURL)
+	acme, pool := placedAdminTenant(t, databaseURL)
+	session := loginSession(t, baseURL)
+
+	invited := postGraphAuthed(t, ctx, session, baseURL,
+		`{"query":"mutation { invite(email: \"maria@example.com\", name: \"Maria Perez\") { delivered } }"}`)
+	if !strings.Contains(invited, `"delivered":false`) {
+		t.Fatalf("invite = %q, want it answered for hand delivery without a relay", invited)
+	}
+
+	invitee, err := authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
+	if err != nil {
+		t.Fatalf("reading the invited account: %v", err)
+	}
+	placed, err := postgres.NewTenantStore(pool).TenantForUser(t.Context(), invitee.ID)
+	if err != nil {
+		t.Fatalf("TenantForUser() error = %v, want nil", err)
+	}
+	if placed.ID != acme {
+		t.Errorf("the invited account stands in %s, want the inviter's tenant %s", placed.ID, acme)
+	}
+}

--- a/cmd/alphone/publicurl_test.go
+++ b/cmd/alphone/publicurl_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/gopherium/alphone/sdk"
+)
+
+var errDepsRecorded = errors.New("the dependencies were recorded")
+
+// recordedPublicURL boots run with env, answering the public URL the host handed the plugins.
+func recordedPublicURL(t *testing.T, env map[string]string) string {
+	t.Helper()
+	env["ALPHONE_DATABASE_URL"] = testDatabaseURL(t)
+	var handed string
+	recording := func(deps sdk.Deps) ([]sdk.Plugin, error) {
+		handed = deps.PublicURL
+		return nil, errDepsRecorded
+	}
+
+	err := run(t.Context(), testGetenv(env), io.Discard, recording)
+
+	if !errors.Is(err, errDepsRecorded) {
+		t.Fatalf("run() error = %v, want the recording plugin's own refusal", err)
+	}
+	return handed
+}
+
+func TestRunHandsThePublicURLToPlugins(t *testing.T) {
+	t.Parallel()
+
+	handed := recordedPublicURL(t, map[string]string{
+		"ALPHONE_SMTP_HOST":  "127.0.0.1",
+		"ALPHONE_SMTP_PORT":  "2525",
+		"ALPHONE_SMTP_FROM":  "crm@example.com",
+		"ALPHONE_SMTP_TLS":   "none",
+		"ALPHONE_PUBLIC_URL": "https://crm.example.com",
+	})
+
+	if handed != "https://crm.example.com" {
+		t.Errorf("plugins received public URL %q, want the configured address", handed)
+	}
+}
+
+func TestRunHandsAnEmptyPublicURLWithoutARelay(t *testing.T) {
+	t.Parallel()
+
+	handed := recordedPublicURL(t, map[string]string{})
+
+	if strings.TrimSpace(handed) != "" {
+		t.Errorf("plugins received public URL %q, want none without a relay", handed)
+	}
+}

--- a/cmd/alphone/run.go
+++ b/cmd/alphone/run.go
@@ -195,7 +195,8 @@ func adminConfig(store *authkitpg.UserStore) authkit.AdminConfig {
 	return authkit.AdminConfig{Store: store, Privileged: role.Privileged()}
 }
 
-// declarePluginRoles registers the plugins and grants the registry every role they declare.
+// declarePluginRoles registers the plugins over the settings a role declaration needs and grants
+// the registry every role they declare.
 func declarePluginRoles(
 	registry *role.Registry,
 	getenv func(string) string,

--- a/cmd/alphone/run.go
+++ b/cmd/alphone/run.go
@@ -78,6 +78,7 @@ func run(
 	resolver := contact.NewResolver(contacts, contact.WithEvents(events))
 	registered, err := plugins(sdk.Deps{
 		DatabaseURL: settings.databaseURL,
+		PublicURL:   settings.mail.publicURL,
 		Resolver:    resolverBridge{resolver: resolver},
 		Contacts:    directoryBridge{resolver: resolver},
 		Events:      pluginPublisher{publisher: events},
@@ -106,23 +107,25 @@ func run(
 
 	auth := authkit.New(authConfig(userStore))
 	admin := authkit.NewAdmin(adminConfig(userStore))
+	inviteConfig := authkit.InvitesConfig{
+		Store:           userStore,
+		InviteTTL:       settings.inviteTTL,
+		ResetTTL:        settings.reset.ttl,
+		ResetTokensLive: settings.reset.links,
+	}
 	graphRoot, err := graphroot.FromPlugins(&graphres.Resolver{
-		Version:  version.Version(),
-		Contacts: contacts,
-		Tasks:    tasks,
-		Webhooks: webhooks,
-		Tenants:  tenants,
-		Tokens:   tokens,
-		Events:   events,
-		Live:     hub,
-		Auth:     auth,
-		Admin:    admin,
-		Invites: authkit.NewInvites(authkit.InvitesConfig{
-			Store:           userStore,
-			InviteTTL:       settings.inviteTTL,
-			ResetTTL:        settings.reset.ttl,
-			ResetTokensLive: settings.reset.links,
-		}),
+		Version:       version.Version(),
+		Contacts:      contacts,
+		Tasks:         tasks,
+		Webhooks:      webhooks,
+		Tenants:       tenants,
+		Tokens:        tokens,
+		Events:        events,
+		Live:          hub,
+		Auth:          auth,
+		Admin:         admin,
+		Invites:       authkit.NewInvites(inviteConfig),
+		Onboarding:    postgres.NewOnboarding(pool, inviteConfig),
 		Accounts:      userStore,
 		Mailer:        mailer,
 		PublicURL:     settings.mail.publicURL,

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,21 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 100%
         threshold: 0%
     patch:
       default:
         target: 100%
 
 ignore:
-  - "internal/postgres/db"
-  - "internal/testdb"
-  - "internal/graphroot"
-  - "graph/generated.go"
-  - "graph/model"
+  - internal/postgres/db
+  - internal/testdb
+  - internal/graphroot
+  - graph/generated.go
+  - graph/model
+  - frontend/src/gql
+  - cmd/alphone/main.go
+  - cmd/alphone/plugins_gen.go
+  - cmd/pluginwire/main.go
+  - cmd/doclint/main.go
+  - cmd/schemagen/main.go

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,21 +2,15 @@ coverage:
   status:
     project:
       default:
-        target: 100%
+        target: auto
         threshold: 0%
     patch:
       default:
         target: 100%
 
 ignore:
-  - internal/postgres/db
-  - internal/testdb
-  - internal/graphroot
-  - graph/generated.go
-  - graph/model
-  - frontend/src/gql
-  - cmd/alphone/main.go
-  - cmd/alphone/plugins_gen.go
-  - cmd/pluginwire/main.go
-  - cmd/doclint/main.go
-  - cmd/schemagen/main.go
+  - "internal/postgres/db"
+  - "internal/testdb"
+  - "internal/graphroot"
+  - "graph/generated.go"
+  - "graph/model"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gopherium/framework/mailkit v0.1.0
 	github.com/gopherium/gouncer v0.4.0
 	github.com/gopherium/gouncer/authkit v0.15.0
-	github.com/gopherium/gouncer/authkit/postgres v0.10.0
+	github.com/gopherium/gouncer/authkit/postgres v0.11.0
 	github.com/gopherium/gouncer/authkit/ratelimit v0.3.0
 	github.com/gopherium/pluginkit v0.5.0
 	github.com/gopherium/pluginkit/graphwire v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/gopherium/gouncer v0.4.0 h1:dkbCD5oeYuuzR961UKGsAvnTvF8vTstlFbN94rP4T
 github.com/gopherium/gouncer v0.4.0/go.mod h1:WwPOu8LyRikot0EODySSu46zaHcWTPbl5nOes4I3H2U=
 github.com/gopherium/gouncer/authkit v0.15.0 h1:yng4mH4TG65kG314eIs9gx2TU1EhLz/+XYuhZPHOlLM=
 github.com/gopherium/gouncer/authkit v0.15.0/go.mod h1:eQU0bybVcopHrAP+GPOYmxfnNIDfmSZ6d8RG4YgeUw0=
-github.com/gopherium/gouncer/authkit/postgres v0.10.0 h1:IpeH9q0xViVd2bhhOqT0xiSgy7+1bMM77udZCAKx2J0=
-github.com/gopherium/gouncer/authkit/postgres v0.10.0/go.mod h1:dkjjTekQk7qe2aImA7lUrxsZf5LHf34vjWc8qqtCCMg=
+github.com/gopherium/gouncer/authkit/postgres v0.11.0 h1:0eXp7xV/AYAn4NCiWLzB0BZCc9LHjLpcdZxXp30X4g0=
+github.com/gopherium/gouncer/authkit/postgres v0.11.0/go.mod h1:60KQIrXfnltT+92/8wLEdlU5Mfe8FPxPJ5NFj73vxL8=
 github.com/gopherium/gouncer/authkit/ratelimit v0.3.0 h1:K4e8kwzO9XRJB95TErMVV4CuskTtG2c2CwL7nLAI/Ko=
 github.com/gopherium/gouncer/authkit/ratelimit v0.3.0/go.mod h1:Nezx00JuDgpuM62iF09HIfYD6nE4X22VvciY8wu3W3E=
 github.com/gopherium/pluginkit v0.5.0 h1:vJPqQXnC+Hxzi5iGqmbxNYtnSk9s5794PY7H80KcSAo=

--- a/graph/budget_test.go
+++ b/graph/budget_test.go
@@ -14,7 +14,7 @@ import (
 // Root field budgets per schema owner.
 const (
 	coreRootFieldBudget   = 32
-	pluginRootFieldBudget = 10
+	pluginRootFieldBudget = 12
 )
 
 // pluginGraphDirs returns the graph directory of every plugin under every plugin root.

--- a/internal/graphres/auth_test.go
+++ b/internal/graphres/auth_test.go
@@ -25,11 +25,13 @@ const testPassword = "password1234"
 
 // newAuthResolver returns a resolver whose auth seams serve store.
 func newAuthResolver(store *testkit.Store) *graphres.Resolver {
+	invites := authkit.NewInvites(authkit.InvitesConfig{Store: store})
 	return &graphres.Resolver{
 		Version:      "9.9.9",
 		Auth:         authkit.New(authkit.Config{Store: store, CookieName: "alphone_session"}),
 		Admin:        authkit.NewAdmin(authkit.AdminConfig{Store: store}),
-		Invites:      authkit.NewInvites(authkit.InvitesConfig{Store: store}),
+		Invites:      invites,
+		Onboarding:   &placingInvites{invites: invites, placed: map[string]uuid.UUID{}},
 		Accounts:     store,
 		LoginLimiter: ratelimit.NewLimiter(ratelimit.Config{Limit: 2, Window: time.Minute}),
 		TokenLimiter: ratelimit.NewLimiter(ratelimit.Config{Limit: 8, Window: time.Minute}),

--- a/internal/graphres/graphres.go
+++ b/internal/graphres/graphres.go
@@ -156,6 +156,11 @@ type AccountReader interface {
 	UserByEmail(ctx context.Context, email string) (gouncer.User, error)
 }
 
+// Onboarder invites an account into a tenant as one transaction.
+type Onboarder interface {
+	InviteInto(ctx context.Context, tenantID uuid.UUID, email, name, role string) (gouncer.Token, error)
+}
+
 // Resolver is the root resolver serving the core schema.
 type Resolver struct {
 	// Version is the reported application version.
@@ -186,6 +191,8 @@ type Resolver struct {
 	Invites *authkit.Invites
 	// Accounts reads accounts for the mail the flows deliver.
 	Accounts AccountReader
+	// Onboarding invites accounts into the caller's tenant.
+	Onboarding Onboarder
 	// Mailer delivers the account mail. Nil runs without a mailer.
 	Mailer Mailer
 	// PublicURL is the address email links lead back to, empty without a mailer.

--- a/internal/graphres/invite.go
+++ b/internal/graphres/invite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gopherium/alphone/graph/model"
 	"github.com/gopherium/alphone/internal/mail"
 	"github.com/gopherium/alphone/internal/role"
+	"github.com/gopherium/alphone/sdk"
 )
 
 // errTokenInvalid refuses a spent, expired or unknown single use link.
@@ -40,7 +41,7 @@ func (m MutationResolvers) Invite(
 	if !role.Outranks(role.Role(actor.Role), stood) {
 		return nil, role.ErrBeyondReach
 	}
-	token, err := m.root.Invites.Invite(ctx, email, name, stood.String())
+	token, err := m.root.Onboarding.InviteInto(ctx, sdk.TenantOrDefault(ctx), email, name, stood.String())
 	if errors.Is(err, gouncer.ErrEmailTaken) {
 		return m.resend(ctx, email)
 	}

--- a/internal/graphres/invite_test.go
+++ b/internal/graphres/invite_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/gopherium/gouncer"
 	"github.com/gopherium/gouncer/authkit"
 	"github.com/gopherium/gouncer/authkit/ratelimit"
 	"github.com/gopherium/gouncer/authkit/testkit"
@@ -59,13 +60,43 @@ func (m *recordingMailer) SendReset(_ context.Context, to, name, link string) er
 	return nil
 }
 
+// placingInvites invites through the store and records the tenant each address was handed to.
+type placingInvites struct {
+	invites *authkit.Invites
+	mu      sync.Mutex
+	placed  map[string]uuid.UUID
+}
+
+// InviteInto invites the address through the store and records tenantID against it.
+func (p *placingInvites) InviteInto(
+	ctx context.Context, tenantID uuid.UUID, email, name, role string,
+) (gouncer.Token, error) {
+	token, err := p.invites.Invite(ctx, email, name, role)
+	if err != nil {
+		return token, err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.placed[email] = tenantID
+	return token, nil
+}
+
+// placedIn answers the tenant the address was handed to, the zero id when none was.
+func (p *placingInvites) placedIn(email string) uuid.UUID {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.placed[email]
+}
+
 // newInviteResolver returns a resolver serving the invite flows over store and mailer.
 func newInviteResolver(store *testkit.Store, mailer graphres.Mailer) *graphres.Resolver {
+	invites := authkit.NewInvites(authkit.InvitesConfig{Store: store, ResetTokensLive: 3})
 	held := &graphres.Resolver{
 		Version:      "9.9.9",
 		Auth:         authkit.New(authkit.Config{Store: store, CookieName: "alphone_session"}),
 		Admin:        authkit.NewAdmin(authkit.AdminConfig{Store: store}),
-		Invites:      authkit.NewInvites(authkit.InvitesConfig{Store: store, ResetTokensLive: 3}),
+		Invites:      invites,
+		Onboarding:   &placingInvites{invites: invites, placed: map[string]uuid.UUID{}},
 		Accounts:     store,
 		PublicURL:    "https://crm.example.com",
 		LoginLimiter: ratelimit.NewLimiter(ratelimit.Config{Limit: 2, Window: time.Minute}),

--- a/internal/graphres/inviteplacement_test.go
+++ b/internal/graphres/inviteplacement_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package graphres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gouncer"
+	"github.com/gopherium/gouncer/authkit"
+	authkitpg "github.com/gopherium/gouncer/authkit/postgres"
+	"github.com/gopherium/gouncer/authkit/testkit"
+
+	"github.com/gopherium/alphone/internal/graphres"
+	"github.com/gopherium/alphone/internal/postgres"
+	"github.com/gopherium/alphone/internal/role"
+	"github.com/gopherium/alphone/internal/tenant"
+	"github.com/gopherium/alphone/sdk"
+)
+
+// newPlacingResolver returns a resolver inviting over the real stores on pool.
+func newPlacingResolver(pool *pgxpool.Pool) *graphres.Resolver {
+	users := authkitpg.NewUserStore(pool)
+	config := authkit.InvitesConfig{Store: users}
+	return &graphres.Resolver{
+		Version:    "9.9.9",
+		Invites:    authkit.NewInvites(config),
+		Onboarding: postgres.NewOnboarding(pool, config),
+		Accounts:   users,
+		Tenants:    postgres.NewTenantStore(pool),
+		PublicURL:  "https://crm.example.com",
+	}
+}
+
+// inviteFrom runs the invite mutation for maria@example.com as an admin standing in tenantID.
+func inviteFrom(t *testing.T, resolver *graphres.Resolver, tenantID uuid.UUID) {
+	t.Helper()
+	actor := authkit.Identity{ID: uuid.Must(uuid.NewV7()), Role: role.Admin.String()}
+	client := newDecoratedGraphClient(t, resolver, func(ctx context.Context) context.Context {
+		return sdk.WithTenant(authkit.WithIdentity(ctx, actor), tenantID)
+	})
+	var response struct {
+		Invite invitePayload `json:"invite"`
+	}
+	client.MustPost(
+		`mutation { invite(email: "maria@example.com", name: "Maria Perez") { delivered activationLink } }`,
+		&response,
+	)
+}
+
+// invitedAccount reads the account the invite created.
+func invitedAccount(t *testing.T, pool *pgxpool.Pool) gouncer.User {
+	t.Helper()
+	held, err := authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
+	if err != nil {
+		t.Fatalf("UserByEmail() error = %v, want the invited account", err)
+	}
+	return held
+}
+
+func TestInvitePlacesTheNewAccountInTheActorsTenant(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	acme := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	resolver := newPlacingResolver(pool)
+
+	inviteFrom(t, resolver, acme)
+
+	placed, err := postgres.NewTenantStore(pool).TenantForUser(t.Context(), invitedAccount(t, pool).ID)
+	if err != nil {
+		t.Fatalf("TenantForUser() error = %v, want nil", err)
+	}
+	if placed.ID != acme {
+		t.Errorf("the invited account stands in %s, want the actor's tenant %s", placed.ID, acme)
+	}
+}
+
+func TestInviteLeavesTheInviteeUnplacedWhenTheActorStandsInTheDefault(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	resolver := newPlacingResolver(pool)
+
+	inviteFrom(t, resolver, tenant.DefaultID)
+
+	placed, err := postgres.NewTenantStore(pool).TenantsOf(t.Context(), []uuid.UUID{invitedAccount(t, pool).ID})
+	if err != nil {
+		t.Fatalf("TenantsOf() error = %v, want nil", err)
+	}
+	if len(placed) != 0 {
+		t.Errorf("TenantsOf() = %v, want no membership row when the actor stands in the default tenant", placed)
+	}
+}
+
+func TestInviteHandsTheActorsTenantToTheOnboarding(t *testing.T) {
+	t.Parallel()
+
+	resolver := newInviteResolver(testkit.NewStore(), nil)
+	acme := uuid.Must(uuid.NewV7())
+
+	inviteFrom(t, resolver, acme)
+
+	placing, ok := resolver.Onboarding.(*placingInvites)
+	if !ok {
+		t.Fatalf("Onboarding is %T, want the recording fake", resolver.Onboarding)
+	}
+	if handed := placing.placedIn("maria@example.com"); handed != acme {
+		t.Errorf("the onboarding was handed tenant %s, want the actor's %s", handed, acme)
+	}
+}

--- a/internal/postgres/db/queries.sql.go
+++ b/internal/postgres/db/queries.sql.go
@@ -911,6 +911,21 @@ func (q *Queries) ListWebhookSubscriptionsForUser(ctx context.Context, arg ListW
 	return items, nil
 }
 
+const placeMember = `-- name: PlaceMember :exec
+INSERT INTO core.tenant_members (user_id, tenant_id)
+VALUES ($1::uuid, $2::uuid)
+`
+
+type PlaceMemberParams struct {
+	UserID   uuid.UUID
+	TenantID uuid.UUID
+}
+
+func (q *Queries) PlaceMember(ctx context.Context, arg PlaceMemberParams) error {
+	_, err := q.db.Exec(ctx, placeMember, arg.UserID, arg.TenantID)
+	return err
+}
+
 const revokeAPIToken = `-- name: RevokeAPIToken :execrows
 DELETE FROM core.api_tokens
 WHERE id = $1 AND user_id = $2 AND tenant_id = $3

--- a/internal/postgres/onboarding.go
+++ b/internal/postgres/onboarding.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gouncer"
+	"github.com/gopherium/gouncer/authkit"
+	authkitpg "github.com/gopherium/gouncer/authkit/postgres"
+
+	"github.com/gopherium/alphone/internal/postgres/db"
+	"github.com/gopherium/alphone/internal/tenant"
+)
+
+// Onboarding invites an account and places it in a tenant as one transaction.
+type Onboarding struct {
+	pool   *pgxpool.Pool
+	users  *authkitpg.UserStore
+	config authkit.InvitesConfig
+}
+
+// NewOnboarding returns an Onboarding inviting under config over pool.
+func NewOnboarding(pool *pgxpool.Pool, config authkit.InvitesConfig) *Onboarding {
+	return &Onboarding{pool: pool, users: authkitpg.NewUserStore(pool), config: config}
+}
+
+// InviteInto creates the invited account, its token and its membership in tenantID as one transaction.
+func (o *Onboarding) InviteInto(
+	ctx context.Context, tenantID uuid.UUID, email, name, role string,
+) (gouncer.Token, error) {
+	tx, err := o.pool.Begin(ctx)
+	if err != nil {
+		return gouncer.Token{}, fmt.Errorf("invite: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	scoped := o.config
+	scoped.Store = o.users.Within(tx)
+	token, err := authkit.NewInvites(scoped).Invite(ctx, email, name, role)
+	if err != nil {
+		return gouncer.Token{}, err
+	}
+	if tenantID != tenant.DefaultID {
+		placement := db.PlaceMemberParams{UserID: token.UserID, TenantID: tenantID}
+		if err := db.New(tx).PlaceMember(ctx, placement); err != nil {
+			return gouncer.Token{}, fmt.Errorf("place member: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return gouncer.Token{}, fmt.Errorf("invite: %w", err)
+	}
+	return token, nil
+}

--- a/internal/postgres/onboarding_test.go
+++ b/internal/postgres/onboarding_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Elastic-2.0
+
+package postgres_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/gopherium/gouncer"
+	"github.com/gopherium/gouncer/authkit"
+	authkitpg "github.com/gopherium/gouncer/authkit/postgres"
+
+	"github.com/gopherium/alphone/internal/postgres"
+	"github.com/gopherium/alphone/internal/tenant"
+)
+
+// standingTenant stores a tenant named Acme and returns its id.
+func standingTenant(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	acme := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(t.Context(),
+		"INSERT INTO core.tenants (id, name) VALUES ($1, $2)", acme, "Acme"); err != nil {
+		t.Fatalf("seeding the tenant: %v", err)
+	}
+	return acme
+}
+
+func TestInviteIntoPlacesTheAccountInTheTenant(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	acme := standingTenant(t, pool)
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+
+	token, err := onboarding.InviteInto(t.Context(), acme, "maria@example.com", "Maria Perez", "member")
+
+	if err != nil {
+		t.Fatalf("InviteInto() error = %v, want nil", err)
+	}
+	placed, err := postgres.NewTenantStore(pool).TenantForUser(t.Context(), token.UserID)
+	if err != nil {
+		t.Fatalf("TenantForUser() error = %v, want nil", err)
+	}
+	if placed.ID != acme {
+		t.Errorf("the invited account stands in %s, want the Acme tenant %s", placed.ID, acme)
+	}
+}
+
+func TestInviteIntoLeavesTheDefaultTenantsAccountUnplaced(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+
+	token, err := onboarding.InviteInto(
+		t.Context(), tenant.DefaultID, "maria@example.com", "Maria Perez", "member")
+
+	if err != nil {
+		t.Fatalf("InviteInto() error = %v, want nil", err)
+	}
+	placed, err := postgres.NewTenantStore(pool).TenantsOf(t.Context(), []uuid.UUID{token.UserID})
+	if err != nil {
+		t.Fatalf("TenantsOf() error = %v, want nil", err)
+	}
+	if len(placed) != 0 {
+		t.Errorf("TenantsOf() = %v, want no membership row for an invite into the default tenant", placed)
+	}
+}
+
+func TestInviteIntoLeavesNoAccountWhenThePlacementFails(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+	unknownTenant := uuid.Must(uuid.NewV7())
+
+	_, err := onboarding.InviteInto(t.Context(), unknownTenant, "maria@example.com", "Maria Perez", "member")
+
+	if err == nil {
+		t.Fatal("InviteInto() error = nil, want the placement refused")
+	}
+	_, err = authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
+	if !errors.Is(err, gouncer.ErrUserNotFound) {
+		t.Errorf("UserByEmail() error = %v, want ErrUserNotFound after the rollback", err)
+	}
+}
+
+func TestInviteIntoPassesATakenEmailThrough(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	acme := standingTenant(t, pool)
+	held, err := gouncer.NewInvitedUser("maria@example.com", "Maria Perez")
+	if err != nil {
+		t.Fatalf("gouncer.NewInvitedUser() error = %v, want nil", err)
+	}
+	if err := authkitpg.NewUserStore(pool).CreateUser(t.Context(), held); err != nil {
+		t.Fatalf("CreateUser() error = %v, want nil", err)
+	}
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+
+	_, err = onboarding.InviteInto(t.Context(), acme, "maria@example.com", "Maria Perez", "member")
+
+	if !errors.Is(err, gouncer.ErrEmailTaken) {
+		t.Errorf("InviteInto() error = %v, want ErrEmailTaken passed through", err)
+	}
+}

--- a/internal/postgres/onboarding_test.go
+++ b/internal/postgres/onboarding_test.go
@@ -28,6 +28,25 @@ func standingTenant(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 	return acme
 }
 
+// refuseAtCommit makes every membership row raise when the transaction commits.
+func refuseAtCommit(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	statements := []string{
+		`CREATE FUNCTION core.refuse_at_commit() RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			RAISE EXCEPTION 'the membership stands refused';
+		END;
+		$$`,
+		`CREATE CONSTRAINT TRIGGER refuse_membership AFTER INSERT ON core.tenant_members
+		DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION core.refuse_at_commit()`,
+	}
+	for _, statement := range statements {
+		if _, err := pool.Exec(t.Context(), statement); err != nil {
+			t.Fatalf("arming the deferred refusal: %v", err)
+		}
+	}
+}
+
 func TestInviteIntoPlacesTheAccountInTheTenant(t *testing.T) {
 	t.Parallel()
 
@@ -85,6 +104,40 @@ func TestInviteIntoLeavesNoAccountWhenThePlacementFails(t *testing.T) {
 	_, err = authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
 	if !errors.Is(err, gouncer.ErrUserNotFound) {
 		t.Errorf("UserByEmail() error = %v, want ErrUserNotFound after the rollback", err)
+	}
+}
+
+func TestInviteIntoRefusesWhenTheTransactionCannotBegin(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+	pool.Close()
+
+	_, err := onboarding.InviteInto(
+		t.Context(), tenant.DefaultID, "maria@example.com", "Maria Perez", "member")
+
+	if err == nil {
+		t.Fatal("InviteInto() error = nil, want the closed pool refused")
+	}
+}
+
+func TestInviteIntoRefusesWhenTheTransactionCannotCommit(t *testing.T) {
+	t.Parallel()
+
+	pool := newTestPool(t)
+	acme := standingTenant(t, pool)
+	refuseAtCommit(t, pool)
+	onboarding := postgres.NewOnboarding(pool, authkit.InvitesConfig{})
+
+	_, err := onboarding.InviteInto(t.Context(), acme, "maria@example.com", "Maria Perez", "member")
+
+	if err == nil {
+		t.Fatal("InviteInto() error = nil, want the refused commit reported")
+	}
+	_, err = authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
+	if !errors.Is(err, gouncer.ErrUserNotFound) {
+		t.Errorf("UserByEmail() error = %v, want ErrUserNotFound after the refused commit", err)
 	}
 }
 

--- a/internal/postgres/onboarding_test.go
+++ b/internal/postgres/onboarding_test.go
@@ -4,6 +4,7 @@ package postgres_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -132,8 +133,8 @@ func TestInviteIntoRefusesWhenTheTransactionCannotCommit(t *testing.T) {
 
 	_, err := onboarding.InviteInto(t.Context(), acme, "maria@example.com", "Maria Perez", "member")
 
-	if err == nil {
-		t.Fatal("InviteInto() error = nil, want the refused commit reported")
+	if err == nil || !strings.Contains(err.Error(), "the membership stands refused") {
+		t.Fatalf("InviteInto() error = %v, want the refusal the commit raised", err)
 	}
 	_, err = authkitpg.NewUserStore(pool).UserByEmail(t.Context(), "maria@example.com")
 	if !errors.Is(err, gouncer.ErrUserNotFound) {

--- a/internal/postgres/queries.sql
+++ b/internal/postgres/queries.sql
@@ -216,6 +216,10 @@ SELECT user_id, tenant_id
 FROM core.tenant_members
 WHERE user_id = ANY(@ids::uuid[]);
 
+-- name: PlaceMember :exec
+INSERT INTO core.tenant_members (user_id, tenant_id)
+VALUES (@user_id::uuid, @tenant_id::uuid);
+
 -- name: UserSetting :many
 SELECT value
 FROM core.user_settings

--- a/internal/server/graphql_test.go
+++ b/internal/server/graphql_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
+	"github.com/gopherium/gouncer"
 	"github.com/gopherium/gouncer/authkit"
 	"github.com/gopherium/gouncer/authkit/ratelimit"
 
@@ -21,6 +24,18 @@ import (
 	"github.com/gopherium/alphone/internal/server"
 	"github.com/gopherium/alphone/sdk"
 )
+
+// unplacedOnboarding invites through the store and places the account in no tenant.
+type unplacedOnboarding struct {
+	invites *authkit.Invites
+}
+
+// InviteInto invites the address, leaving the tenant it names untouched.
+func (o unplacedOnboarding) InviteInto(
+	ctx context.Context, _ uuid.UUID, email, name, role string,
+) (gouncer.Token, error) {
+	return o.invites.Invite(ctx, email, name, role)
+}
 
 // graphConfig carries the stores and bounds a test graph server composes.
 type graphConfig struct {
@@ -72,7 +87,9 @@ func newSubscribingGraphServer(t *testing.T, cfg graphConfig, hub *event.Hub) ht
 		TokenLimiter: ratelimit.NewLimiter(ratelimit.Config{}),
 	}
 	if store, ok := cfg.Users.(authkit.InviteStore); ok {
-		resolver.Invites = authkit.NewInvites(authkit.InvitesConfig{Store: store})
+		invites := authkit.NewInvites(authkit.InvitesConfig{Store: store})
+		resolver.Invites = invites
+		resolver.Onboarding = unplacedOnboarding{invites: invites}
 		resolver.Accounts = store
 	}
 	if hub != nil {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -45,10 +45,12 @@ type PublicPathProvider = pluginkit.PublicPathProvider
 // which the host calls once per installed plugin.
 type Deps struct {
 	DatabaseURL string
-	Resolver    ContactResolver
-	Contacts    ContactDirectory
-	Getenv      func(string) string
-	Events      Publisher
+	// PublicURL is the address people reach the application at, empty without a mail relay.
+	PublicURL string
+	Resolver  ContactResolver
+	Contacts  ContactDirectory
+	Getenv    func(string) string
+	Events    Publisher
 }
 
 // Publisher announces a plugin's own events to the host.

--- a/test/features/world_test.go
+++ b/test/features/world_test.go
@@ -131,6 +131,7 @@ func bootWorld(t *testing.T, liveImports bool) *world {
 	if err != nil {
 		t.Fatalf("building the scenario mailer: %v", err)
 	}
+	inviteConfig := authkit.InvitesConfig{Store: users}
 	root, err := graphroot.FromPlugins(&graphres.Resolver{
 		Version:      "test",
 		Contacts:     contacts,
@@ -142,7 +143,8 @@ func bootWorld(t *testing.T, liveImports bool) *world {
 		Live:         hub,
 		Auth:         auth,
 		Admin:        authkit.NewAdmin(authkit.AdminConfig{Store: users, Privileged: role.Privileged()}),
-		Invites:      authkit.NewInvites(authkit.InvitesConfig{Store: users}),
+		Invites:      authkit.NewInvites(inviteConfig),
+		Onboarding:   postgres.NewOnboarding(pool, inviteConfig),
 		Accounts:     users,
 		Mailer:       mailer,
 		PublicURL:    scenarioPublicURL,


### PR DESCRIPTION
Closes #113
Closes #114

## What

An invitation now creates the account, its activation link and its tenant membership in one transaction, placing the new person in the inviter's tenant. An inviter in the default tenant places nobody. Plugins also receive the app's public address in their dependencies.

## Why

Today an invited person lands in the default tenant and sees its data instead of their own tenant's, and a tenant cannot grow past one person without an operator. A plugin building links needs the public address the host already holds.

## Testing

Run the testing toolchain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inviting an account from a tenant now places the invited account in that tenant.
  * Plugins can access the application’s configured public URL.
  * Invitation and onboarding settings are now applied consistently across related flows.

* **Bug Fixes**
  * Invitation placement now occurs transactionally, preventing incomplete accounts when placement fails.

* **Tests**
  * Added coverage for tenant placement, rollback behavior, default-tenant handling, and public URL delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->